### PR TITLE
feat(security): add shodan-recon skill

### DIFF
--- a/security/shodan-recon/SKILL.md
+++ b/security/shodan-recon/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: shodan-recon
+version: 1.0.0
+description: Query Shodan for internet-facing asset intelligence, exposure analysis, and threat enrichment.
+triggers:
+  - shodan
+  - exposed services
+  - internet exposure
+  - attack surface
+  - open ports
+  - asset discovery
+  - IP reconnaissance
+tools:
+  - bash
+env:
+  - SHODAN_API_KEY
+---
+
+# Shodan Reconnaissance
+
+Query the Shodan API for internet-facing asset intelligence. Use for exposure analysis, threat enrichment, vulnerability correlation, and attack surface mapping.
+
+## Prerequisites
+
+- `SHODAN_API_KEY` environment variable must be set
+- Free tier: 100 queries/month | Membership: unlimited
+
+## Commands
+
+### Search hosts by query
+```bash
+bash scripts/shodan-search.sh "query" [limit]
+```
+Search Shodan's database. Uses Shodan search syntax (e.g., `org:"Target Corp"`, `port:22 country:US`, `vuln:CVE-2026-1731`).
+
+### Get host details by IP
+```bash
+bash scripts/shodan-host.sh <ip>
+```
+Returns open ports, services, banners, vulnerabilities, and geolocation for a specific IP.
+
+### Check exploit availability
+```bash
+bash scripts/shodan-exploits.sh "query" [limit]
+```
+Search Shodan's exploit database for known exploits matching a query (CVE ID, product name, etc.).
+
+## Query Syntax Examples
+
+| Query | Description |
+|-------|-------------|
+| `port:3389 country:US` | RDP exposed in the US |
+| `vuln:CVE-2026-1731` | Hosts vulnerable to specific CVE |
+| `org:"Company Name"` | Assets belonging to an organization |
+| `product:nginx city:"Birmingham"` | Nginx servers in Birmingham |
+| `ssl.cert.subject.CN:"example.com"` | Hosts with specific SSL cert |
+| `has_vuln:true port:443` | HTTPS hosts with known vulns |
+
+## Use Cases
+
+1. **Threat enrichment** — Look up IPs from OpenCTI IOCs for context
+2. **Exposure monitoring** — Check if specific services are internet-facing
+3. **Vulnerability correlation** — Find hosts affected by a CVE being tracked
+4. **Attack surface mapping** — Enumerate an organization's exposed assets
+5. **Incident investigation** — Profile attacker infrastructure
+
+## Output
+
+All scripts output JSON. Parse with standard tools or pass to report-generator skill for formatted output.
+
+## Rate Limits
+
+- Free API: 1 query/second, 100 queries/month
+- Membership: 1 query/second, unlimited queries
+- Scripts include 1-second delays between paginated requests

--- a/security/shodan-recon/scripts/shodan-exploits.sh
+++ b/security/shodan-recon/scripts/shodan-exploits.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# shodan-exploits.sh — Search Shodan's exploit database.
+# Usage: shodan-exploits.sh "query" [limit]
+# Requires: SHODAN_API_KEY env var
+set -euo pipefail
+
+QUERY="${1:?Usage: shodan-exploits.sh \"query\" [limit]}"
+LIMIT="${2:-5}"
+API_KEY="${SHODAN_API_KEY:?SHODAN_API_KEY not set}"
+
+ENCODED_QUERY=$(printf '%s' "$QUERY" | sed 's/ /%20/g; s/"/%22/g; s/:/%3A/g')
+
+RESPONSE=$(curl -s --max-time 30 \
+  "https://api.shodan.io/api-info?key=${API_KEY}")
+
+# Check API credits first
+echo "=== API Info ==="
+echo "$RESPONSE"
+echo ""
+
+# Search exploits
+RESPONSE=$(curl -s --max-time 30 \
+  "https://exploits.shodan.io/api/search?query=${ENCODED_QUERY}&key=${API_KEY}&page=1")
+
+ERROR=$(echo "$RESPONSE" | grep -o '"error":[^,}]*' | head -1 || true)
+if [ -n "$ERROR" ]; then
+  echo "Shodan Exploits API error: $ERROR" >&2
+  echo "$RESPONSE"
+  exit 1
+fi
+
+TOTAL=$(echo "$RESPONSE" | grep -o '"total":[0-9]*' | head -1 | cut -d: -f2)
+echo "=== Shodan Exploit Search ==="
+echo "Query: $QUERY"
+echo "Total matches: ${TOTAL:-unknown}"
+echo "==="
+echo ""
+echo "$RESPONSE"

--- a/security/shodan-recon/scripts/shodan-host.sh
+++ b/security/shodan-recon/scripts/shodan-host.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# shodan-host.sh — Get detailed information about a specific IP from Shodan.
+# Usage: shodan-host.sh <ip>
+# Requires: SHODAN_API_KEY env var
+set -euo pipefail
+
+IP="${1:?Usage: shodan-host.sh <ip>}"
+API_KEY="${SHODAN_API_KEY:?SHODAN_API_KEY not set}"
+
+# Validate IP format (basic check)
+if ! echo "$IP" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "Error: '$IP' does not look like a valid IPv4 address" >&2
+  exit 1
+fi
+
+RESPONSE=$(curl -s --max-time 30 \
+  "https://api.shodan.io/shodan/host/${IP}?key=${API_KEY}")
+
+# Check for errors
+ERROR=$(echo "$RESPONSE" | grep -o '"error":[^,}]*' | head -1 || true)
+if [ -n "$ERROR" ]; then
+  echo "Shodan API error: $ERROR" >&2
+  echo "$RESPONSE"
+  exit 1
+fi
+
+echo "=== Shodan Host Report: $IP ==="
+echo ""
+echo "$RESPONSE"

--- a/security/shodan-recon/scripts/shodan-search.sh
+++ b/security/shodan-recon/scripts/shodan-search.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# shodan-search.sh — Search Shodan for hosts matching a query.
+# Usage: shodan-search.sh "query" [limit]
+# Requires: SHODAN_API_KEY env var
+set -euo pipefail
+
+QUERY="${1:?Usage: shodan-search.sh \"query\" [limit]}"
+LIMIT="${2:-5}"
+API_KEY="${SHODAN_API_KEY:?SHODAN_API_KEY not set}"
+
+ENCODED_QUERY=$(printf '%s' "$QUERY" | sed 's/ /%20/g; s/"/%22/g; s/:/%3A/g')
+
+RESPONSE=$(curl -s --max-time 30 \
+  "https://api.shodan.io/shodan/host/search?key=${API_KEY}&query=${ENCODED_QUERY}&page=1")
+
+# Check for errors
+ERROR=$(echo "$RESPONSE" | grep -o '"error":[^,}]*' | head -1 || true)
+if [ -n "$ERROR" ]; then
+  echo "Shodan API error: $ERROR" >&2
+  echo "$RESPONSE"
+  exit 1
+fi
+
+# Extract total count
+TOTAL=$(echo "$RESPONSE" | grep -o '"total":[0-9]*' | head -1 | cut -d: -f2)
+echo "=== Shodan Search Results ==="
+echo "Query: $QUERY"
+echo "Total matches: ${TOTAL:-unknown}"
+echo "Showing: up to $LIMIT results"
+echo "==="
+echo ""
+
+# Output the raw JSON for the agent to parse
+echo "$RESPONSE"


### PR DESCRIPTION
New Shodan reconnaissance skill for Galahad.

**Scripts:**
- `shodan-search.sh` — Query Shodan host database with full search syntax
- `shodan-host.sh` — Detailed IP reconnaissance (ports, services, vulns, geo)
- `shodan-exploits.sh` — Search exploit database by CVE or product

**Use cases:** Threat enrichment, exposure monitoring, CVE correlation, attack surface mapping, incident investigation.

Requires `SHODAN_API_KEY` env var (wired via dapper-cluster ExternalSecret).