### PR TITLE
feat: vault-curator and vault-linter skills for Patsy 🥥

### DIFF
--- a/vault/vault-curator/SKILL.md
+++ b/vault/vault-curator/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: vault-curator
+description: Curate the Obsidian vault — enforce frontmatter, manage tags, add wikilinks, process inbox, detect duplicates, and maintain vault health. The core skill for Second Brain organization.
+allowed-tools: Bash Read Write Edit Glob Grep
+metadata:
+  author: roundtable
+  version: "1.0"
+  tier: vault
+---
+
+# Vault Curator
+
+You are the keeper of the Second Brain — an Obsidian vault at `/vault`. Your job is to make sure every note is properly structured, tagged, linked, and findable.
+
+## Vault Location
+
+```
+/vault
+```
+
+## Folder Structure
+
+```
+/vault/
+├── Home.md                 # Dashboard (DO NOT modify)
+├── Journal/                # Daily notes (template-driven)
+│   └── YYYY/MM-Month/
+├── Briefings/              # Auto-generated reports (ephemeral)
+│   ├── Security/
+│   ├── Space Weather/
+│   ├── Daily/
+│   ├── HomeLab/
+│   ├── Knights/
+│   ├── Nerd News/
+│   └── Wizards Workshop/
+├── Research/               # Deep dives, investigations
+├── Projects/               # Project documentation
+├── Personal/               # Family, relationships, preferences
+│   └── Family/
+├── Work/                   # Career, interviews, employment
+├── Roundtable/             # Knight-generated reference docs
+├── Inbox/                  # Unprocessed captures (voice notes)
+│   └── Voice/
+├── Resources/              # Templates, scripts
+│   └── Templates/
+├── Excalidraw/             # Diagrams
+└── Attachments/            # Images, PDFs
+```
+
+## Frontmatter Schema
+
+Every note MUST have YAML frontmatter. This is the standard:
+
+```yaml
+---
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+type: note|reference|project|daily|briefing|research|voice-note|meeting
+status: active|archive|stub|draft
+tags:
+  - domain/security
+  - relevant-entity-tag
+author: Tim|Galahad|Percival|Lancelot|Tristan|Bedivere|Kay|Patsy|Derek
+---
+```
+
+### Required Fields
+- `created` — Date the note was first created (YYYY-MM-DD). If unknown, use file modification date or best guess.
+- `type` — What kind of note this is
+- `tags` — At least one tag. Prefer domain tags + entity tags.
+
+### Optional Fields
+- `updated` — Last meaningful edit date. Add this when you modify a note.
+- `status` — Defaults to `active` if omitted. Use `stub` for incomplete notes, `archive` for outdated content, `draft` for work-in-progress.
+- `author` — Who created it. Add when identifiable.
+
+### Type Values
+| Type | Use For |
+|------|---------|
+| `note` | General notes, thoughts, captures |
+| `reference` | Long-lived reference material |
+| `project` | Project documentation with goals/status |
+| `daily` | Daily journal notes |
+| `briefing` | Auto-generated reports and briefings |
+| `research` | Deep research on a topic |
+| `voice-note` | Transcribed voice captures |
+| `meeting` | Meeting notes |
+| `dashboard` | Navigation/index pages |
+
+## Tag Taxonomy
+
+### Domain Tags (hierarchical — pick the primary domain)
+- `domain/security` — Cybersecurity, threats, vulnerabilities
+- `domain/homelab` — Kubernetes, cluster, infrastructure
+- `domain/family` — Sara, Emma, family events, personal
+- `domain/career` — Interviews, work, professional development
+- `domain/finance` — Money, taxes, budgets, investments
+- `domain/health` — Health, wellness
+- `domain/research` — General research topics
+
+### Entity Tags (flat — specific things mentioned)
+Use lowercase, hyphenated entity tags for searchability:
+- **Tech:** `kubernetes`, `docker`, `talos`, `nats`, `opencti`, `flux`, `helm`, `wazuh`, `obsidian`
+- **People:** `sara`, `emma`, `drake`, `drogo`
+- **Orgs:** `bridgewater`, `mastery`, `clipboard-health`
+- **Projects:** `round-table`, `knight-agent`, `inbox-zero`
+- **Topics:** `interview`, `automation`, `threat-intel`, `supply-chain`
+
+### Tagging Rules
+1. Every note gets at least ONE domain tag
+2. Add entity tags for specific things that someone might search for
+3. Don't over-tag — 3-7 tags is the sweet spot
+4. Don't duplicate information already in the folder path (a note in `Briefings/Security/` doesn't need `domain/security` — but it doesn't hurt)
+5. Clean up legacy junk tags: `type/note`, `area/projects`, empty tags `[]`, bare `-` entries
+
+## Wikilinks
+
+Wikilinks (`[[Note Name]]`) are how the Second Brain thinks. They create the graph.
+
+### When to Add Wikilinks
+- A note mentions a concept that has its own note → link it
+- A note references a project → `[[Project Name]]`
+- A note mentions a person who has a note → `[[Personal/Family/Sara|Sara]]`
+- Related notes should cross-reference each other
+
+### Wikilink Format
+- Basic: `[[Note Name]]`
+- With display text: `[[Folder/Full Note Name|Short Name]]`
+- Only link on FIRST mention in a note (don't link every occurrence)
+- Prefer linking to existing notes over creating new ones
+
+### Don't Over-Link
+- Don't link common words (`the`, `security`, `project`)
+- Don't link things that don't have or need their own note
+- Use judgment: would someone actually follow this link?
+
+## Inbox Processing
+
+The `/vault/Inbox/` folder (especially `/vault/Inbox/Voice/`) collects unprocessed captures.
+
+### Voice Note Processing
+1. Read the transcription
+2. Identify the intent: new knowledge, task, reminder, or thought
+3. Check if the content belongs in an existing note (update it) or needs a new one
+4. If routed elsewhere: add a `routed_to` field in frontmatter, update status to `processed`
+5. If it IS the final note: move it to the correct folder, add proper frontmatter
+
+### Inbox Zero Goal
+The Inbox should be empty after processing. Every item either:
+- Gets merged into an existing note
+- Becomes a properly filed new note
+- Gets archived if it's stale/irrelevant
+
+## Duplicate Detection
+
+### What Counts as a Duplicate
+- Two notes covering the same topic with significant overlap (>50% similar content)
+- A Roundtable/ note that duplicates a Projects/ or Research/ note
+- Multiple briefings summarizing the same event
+
+### How to Handle Duplicates
+1. Identify which version is more complete/recent
+2. Merge unique content from the lesser into the better
+3. Update the keeper's `updated` date
+4. Delete the duplicate (or move to `.trash/` if uncertain)
+5. Add a note in your report: "Merged X into Y"
+
+## Briefing Lifecycle
+
+Briefings are ephemeral — they have a shelf life.
+
+### Rules
+- **Daily briefings** (security, solar weather, nerd news): Archive after 30 days
+- **Weekly summaries**: Keep for 90 days
+- **One-off analyses** (breach reports, investigations): Keep indefinitely — these are reference material
+- **Archive** means: move to a `Briefings/Archive/YYYY-MM/` folder, NOT delete
+
+## Scripts
+
+### vault-health.sh — Scan vault and report issues
+
+```bash
+bash /workspace/skills/vault/vault-linter/scripts/vault-health.sh
+```
+
+Reports: notes missing frontmatter, empty tags, orphan notes (no links in or out), stale inbox items, briefings due for archival.
+
+## Working Principles
+
+1. **Read before writing** — Always check if a note exists before creating a new one
+2. **Preserve content** — Never change the meaning of a note. Fix metadata and links only.
+3. **Incremental improvement** — Don't try to fix everything at once. Prioritize: frontmatter → tags → wikilinks → duplicates
+4. **Report your work** — Always return counts of what you did so Tim knows the vault is being maintained
+5. **Flag decisions** — When you're unsure (delete vs. archive, merge vs. keep both), flag it for human review instead of guessing

--- a/vault/vault-linter/SKILL.md
+++ b/vault/vault-linter/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: vault-linter
+description: Scan the Obsidian vault for structural issues — missing frontmatter, broken tags, orphan notes, stale content, duplicates. Produces actionable health reports.
+allowed-tools: Bash Read Glob Grep
+metadata:
+  author: roundtable
+  version: "1.0"
+  tier: vault
+---
+
+# Vault Linter
+
+Scanning tools for vault health. Use these scripts to identify issues, then use the `vault-curator` skill to fix them.
+
+## Scripts
+
+### vault-health.sh — Full vault health scan
+
+Scans the entire vault and produces a structured report.
+
+```bash
+bash /workspace/skills/vault/vault-linter/scripts/vault-health.sh /vault
+```
+
+### frontmatter-check.sh — Check frontmatter on specific files or folders
+
+```bash
+bash /workspace/skills/vault/vault-linter/scripts/frontmatter-check.sh /vault/Projects
+```
+
+### find-orphans.sh — Find notes with no incoming or outgoing links
+
+```bash
+bash /workspace/skills/vault/vault-linter/scripts/find-orphans.sh /vault
+```
+
+### find-duplicates.sh — Find notes with similar titles or content
+
+```bash
+bash /workspace/skills/vault/vault-linter/scripts/find-duplicates.sh /vault
+```

--- a/vault/vault-linter/scripts/find-duplicates.sh
+++ b/vault/vault-linter/scripts/find-duplicates.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# find-duplicates.sh — Find notes with similar titles suggesting duplication
+# Usage: bash find-duplicates.sh /vault
+set -euo pipefail
+
+VAULT="${1:-/vault}"
+
+echo "# Duplicate Detection Report"
+echo ""
+
+echo "## Similar Titles"
+echo "Notes with similar names that may cover the same topic:"
+echo ""
+
+# Collect all note paths and titles
+tmpfile=$(mktemp)
+find "$VAULT" -name "*.md" \
+  -not -path "*/.obsidian/*" \
+  -not -path "*/.trash/*" \
+  -not -path "*/.stversions/*" \
+  -not -path "*/Resources/Templates/*" | while read -r f; do
+  basename "$f" .md | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/ /g' | tr -s ' '
+  echo "|$f"
+done | paste -d '' - - > "$tmpfile"
+
+# Find titles sharing significant words (3+ char words)
+echo "### Potential Duplicates by Keyword Overlap"
+# Extract key terms from each file and group
+declare -A term_files
+while IFS='|' read -r normalized path; do
+  for word in $normalized; do
+    if [ ${#word} -ge 4 ]; then
+      key="$word"
+      if [ -n "${term_files[$key]:-}" ]; then
+        term_files[$key]="${term_files[$key]}|$path"
+      else
+        term_files[$key]="$path"
+      fi
+    fi
+  done
+done < "$tmpfile"
+
+# Report terms that appear in multiple files (potential duplicates)
+reported=""
+for key in "${!term_files[@]}"; do
+  files="${term_files[$key]}"
+  count=$(echo "$files" | tr '|' '\n' | wc -l)
+  if [ "$count" -ge 2 ] && [ "$count" -le 5 ]; then
+    # Only report interesting clusters, skip very common terms
+    case "$key" in
+      daily|note|report|2026|2025|security|briefing|home)
+        continue
+        ;;
+    esac
+    # Check if we already reported this cluster
+    if echo "$reported" | grep -q "$key"; then
+      continue
+    fi
+    reported="$reported $key"
+    echo "**'$key'** ($count notes):"
+    echo "$files" | tr '|' '\n' | while read -r p; do
+      echo "  - $(echo "$p" | sed "s|$VAULT/||")"
+    done
+    echo ""
+  fi
+done
+
+rm -f "$tmpfile"
+
+echo ""
+echo "## Cross-Folder Overlap"
+echo "Notes in Roundtable/ that may duplicate content in other folders:"
+echo ""
+if [ -d "$VAULT/Roundtable" ]; then
+  find "$VAULT/Roundtable" -name "*.md" -not -name "README.md" | while read -r rt_file; do
+    rt_name=$(basename "$rt_file" .md)
+    # Search for similar names outside Roundtable
+    matches=$(find "$VAULT" -name "*.md" -not -path "*/Roundtable/*" \
+      -not -path "*/.obsidian/*" -not -path "*/.trash/*" \
+      -not -path "*/.stversions/*" | while read -r other; do
+      other_name=$(basename "$other" .md)
+      # Simple keyword overlap check
+      for word in $(echo "$rt_name" | tr '-' ' ' | tr '[:upper:]' '[:lower:]'); do
+        if [ ${#word} -ge 4 ] && echo "$other_name" | tr '-' ' ' | tr '[:upper:]' '[:lower:]' | grep -qw "$word"; then
+          echo "$(echo "$other" | sed "s|$VAULT/||")"
+          break
+        fi
+      done
+    done)
+    if [ -n "$matches" ]; then
+      echo "**$(echo "$rt_file" | sed "s|$VAULT/||")** may overlap with:"
+      echo "$matches" | while read -r m; do echo "  - $m"; done
+      echo ""
+    fi
+  done
+fi
+
+echo "---"
+echo "Review these manually — similar titles don't always mean duplicate content."

--- a/vault/vault-linter/scripts/find-orphans.sh
+++ b/vault/vault-linter/scripts/find-orphans.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# find-orphans.sh — Find notes with no incoming wikilinks from other notes
+# Usage: bash find-orphans.sh /vault
+set -euo pipefail
+
+VAULT="${1:-/vault}"
+
+echo "# Orphan Notes Report"
+echo "Notes that are never linked to from any other note."
+echo ""
+
+# Build list of all note names (without .md)
+declare -A linked_notes
+
+# Find all wikilinks across the vault
+while IFS= read -r -d '' f; do
+  # Extract wikilink targets: [[Target]] or [[Target|Display]]
+  grep -oP '\[\[([^\]|]+)' "$f" 2>/dev/null | sed 's/\[\[//' | while read -r link; do
+    # Normalize: take just the filename part if it includes a path
+    basename_link=$(basename "$link")
+    linked_notes["$basename_link"]=1
+  done
+done < <(find "$VAULT" -name "*.md" \
+  -not -path "*/.obsidian/*" \
+  -not -path "*/.trash/*" \
+  -not -path "*/.stversions/*" \
+  -print0)
+
+# Now check which notes are never linked to
+orphan_count=0
+echo "## Orphan Notes (no incoming links)"
+while IFS= read -r -d '' f; do
+  fname=$(basename "$f" .md)
+  rel=$(echo "$f" | sed "s|$VAULT/||")
+
+  # Skip templates, Home.md, and dotfiles
+  case "$rel" in
+    Resources/Templates/*|Home.md|.*)
+      continue
+      ;;
+  esac
+
+  # Check if this note name appears as a wikilink anywhere
+  if ! grep -rq "\[\[$fname" "$VAULT" --include="*.md" 2>/dev/null | grep -v "$f" >/dev/null 2>&1; then
+    # Double check with path-based links
+    if ! grep -rq "\[\[.*$fname" "$VAULT" --include="*.md" 2>/dev/null; then
+      echo "- $rel"
+      orphan_count=$((orphan_count + 1))
+    fi
+  fi
+done < <(find "$VAULT" -name "*.md" \
+  -not -path "*/.obsidian/*" \
+  -not -path "*/.trash/*" \
+  -not -path "*/.stversions/*" \
+  -not -path "*/Resources/Templates/*" \
+  -print0)
+
+echo ""
+echo "Total orphans: $orphan_count"

--- a/vault/vault-linter/scripts/frontmatter-check.sh
+++ b/vault/vault-linter/scripts/frontmatter-check.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# frontmatter-check.sh — List files missing or with incomplete frontmatter
+# Usage: bash frontmatter-check.sh /vault [folder]
+set -euo pipefail
+
+VAULT="${1:-/vault}"
+FOLDER="${2:-}"
+SEARCH_PATH="$VAULT"
+[ -n "$FOLDER" ] && SEARCH_PATH="$VAULT/$FOLDER"
+
+echo "# Frontmatter Check: $SEARCH_PATH"
+echo ""
+
+echo "## Missing Frontmatter"
+count=0
+while IFS= read -r -d '' f; do
+  if ! head -1 "$f" 2>/dev/null | grep -q "^---"; then
+    echo "- $(echo "$f" | sed "s|$VAULT/||")"
+    count=$((count + 1))
+  fi
+done < <(find "$SEARCH_PATH" -name "*.md" \
+  -not -path "*/.obsidian/*" \
+  -not -path "*/.trash/*" \
+  -not -path "*/.stversions/*" \
+  -not -path "*/Resources/Templates/*" \
+  -print0)
+echo "Total: $count"
+
+echo ""
+echo "## Missing 'created' Field"
+count=0
+while IFS= read -r -d '' f; do
+  if head -1 "$f" 2>/dev/null | grep -q "^---"; then
+    # Extract frontmatter block
+    if ! sed -n '2,/^---$/p' "$f" 2>/dev/null | grep -q "^created:"; then
+      echo "- $(echo "$f" | sed "s|$VAULT/||")"
+      count=$((count + 1))
+    fi
+  fi
+done < <(find "$SEARCH_PATH" -name "*.md" \
+  -not -path "*/.obsidian/*" \
+  -not -path "*/.trash/*" \
+  -not -path "*/.stversions/*" \
+  -not -path "*/Resources/Templates/*" \
+  -print0)
+echo "Total: $count"
+
+echo ""
+echo "## Missing 'type' Field"
+count=0
+while IFS= read -r -d '' f; do
+  if head -1 "$f" 2>/dev/null | grep -q "^---"; then
+    if ! sed -n '2,/^---$/p' "$f" 2>/dev/null | grep -q "^type:"; then
+      echo "- $(echo "$f" | sed "s|$VAULT/||")"
+      count=$((count + 1))
+    fi
+  fi
+done < <(find "$SEARCH_PATH" -name "*.md" \
+  -not -path "*/.obsidian/*" \
+  -not -path "*/.trash/*" \
+  -not -path "*/.stversions/*" \
+  -not -path "*/Resources/Templates/*" \
+  -print0)
+echo "Total: $count"
+
+echo ""
+echo "## Empty or Missing Tags"
+count=0
+while IFS= read -r -d '' f; do
+  if head -1 "$f" 2>/dev/null | grep -q "^---"; then
+    fm=$(sed -n '2,/^---$/p' "$f" 2>/dev/null)
+    if echo "$fm" | grep -q "^tags: \[\]"; then
+      echo "- $(echo "$f" | sed "s|$VAULT/||") (empty array)"
+      count=$((count + 1))
+    elif ! echo "$fm" | grep -q "^tags:"; then
+      echo "- $(echo "$f" | sed "s|$VAULT/||") (missing)"
+      count=$((count + 1))
+    fi
+  fi
+done < <(find "$SEARCH_PATH" -name "*.md" \
+  -not -path "*/.obsidian/*" \
+  -not -path "*/.trash/*" \
+  -not -path "*/.stversions/*" \
+  -not -path "*/Resources/Templates/*" \
+  -print0)
+echo "Total: $count"

--- a/vault/vault-linter/scripts/vault-health.sh
+++ b/vault/vault-linter/scripts/vault-health.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# vault-health.sh — Full vault health scan
+# Usage: bash vault-health.sh /vault
+set -euo pipefail
+
+VAULT="${1:-/vault}"
+
+if [ ! -d "$VAULT" ]; then
+  echo "ERROR: Vault directory not found: $VAULT"
+  exit 1
+fi
+
+echo "# Vault Health Report"
+echo "Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo ""
+
+# Count total notes
+total=$(find "$VAULT" -name "*.md" \
+  -not -path "*/.obsidian/*" \
+  -not -path "*/.trash/*" \
+  -not -path "*/.stversions/*" \
+  -not -path "*/Resources/Templates/*" | wc -l)
+echo "## Summary"
+echo "- Total notes: $total"
+
+# Count by folder
+echo ""
+echo "## Notes by Folder"
+for dir in Briefings Excalidraw Inbox Journal Personal Projects Research Resources Roundtable Work; do
+  if [ -d "$VAULT/$dir" ]; then
+    count=$(find "$VAULT/$dir" -name "*.md" | wc -l)
+    echo "- $dir: $count"
+  fi
+done
+
+# Frontmatter check
+echo ""
+echo "## Frontmatter Status"
+has_fm=0
+no_fm=0
+empty_tags=0
+no_tags=0
+
+while IFS= read -r -d '' f; do
+  if head -1 "$f" 2>/dev/null | grep -q "^---"; then
+    has_fm=$((has_fm + 1))
+    # Check for empty tags
+    if grep -q "^tags: \[\]" "$f" 2>/dev/null || grep -q "^tags:$" "$f" 2>/dev/null; then
+      empty_tags=$((empty_tags + 1))
+    elif ! grep -q "^tags:" "$f" 2>/dev/null; then
+      no_tags=$((no_tags + 1))
+    fi
+  else
+    no_fm=$((no_fm + 1))
+  fi
+done < <(find "$VAULT" -name "*.md" \
+  -not -path "*/.obsidian/*" \
+  -not -path "*/.trash/*" \
+  -not -path "*/.stversions/*" \
+  -not -path "*/Resources/Templates/*" \
+  -print0)
+
+echo "- With frontmatter: $has_fm"
+echo "- Missing frontmatter: $no_fm"
+echo "- Empty/missing tags: $((empty_tags + no_tags))"
+echo "- Empty tag arrays: $empty_tags"
+
+# Wikilinks
+echo ""
+echo "## Wikilink Status"
+has_links=0
+while IFS= read -r -d '' f; do
+  if grep -q '\[\[' "$f" 2>/dev/null; then
+    has_links=$((has_links + 1))
+  fi
+done < <(find "$VAULT" -name "*.md" \
+  -not -path "*/.obsidian/*" \
+  -not -path "*/.trash/*" \
+  -not -path "*/.stversions/*" \
+  -print0)
+echo "- Notes with wikilinks: $has_links / $total"
+echo "- Notes without wikilinks: $((total - has_links))"
+
+# Inbox
+echo ""
+echo "## Inbox Status"
+inbox_count=$(find "$VAULT/Inbox" -name "*.md" 2>/dev/null | wc -l)
+echo "- Unprocessed inbox items: $inbox_count"
+if [ "$inbox_count" -gt 0 ]; then
+  echo "- Files:"
+  find "$VAULT/Inbox" -name "*.md" 2>/dev/null | while read -r f; do
+    echo "  - $(basename "$f")"
+  done
+fi
+
+# Briefing age
+echo ""
+echo "## Briefing Lifecycle"
+thirty_days_ago=$(date -d "30 days ago" +%Y-%m-%d 2>/dev/null || date -v-30d +%Y-%m-%d 2>/dev/null || echo "")
+if [ -n "$thirty_days_ago" ]; then
+  old_briefings=0
+  while IFS= read -r -d '' f; do
+    fname=$(basename "$f")
+    # Extract date from filename (YYYY-MM-DD pattern)
+    fdate=$(echo "$fname" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1)
+    if [ -n "$fdate" ] && [ "$fdate" \< "$thirty_days_ago" ]; then
+      old_briefings=$((old_briefings + 1))
+    fi
+  done < <(find "$VAULT/Briefings" -name "*.md" -print0 2>/dev/null)
+  echo "- Briefings older than 30 days: $old_briefings"
+else
+  echo "- (Could not calculate date threshold)"
+fi
+total_briefings=$(find "$VAULT/Briefings" -name "*.md" 2>/dev/null | wc -l)
+echo "- Total briefings: $total_briefings"
+
+# Stubs (very short notes, likely incomplete)
+echo ""
+echo "## Potential Stubs"
+stub_count=0
+while IFS= read -r -d '' f; do
+  lines=$(wc -l < "$f")
+  if [ "$lines" -lt 5 ]; then
+    stub_count=$((stub_count + 1))
+    echo "  - $(echo "$f" | sed "s|$VAULT/||") ($lines lines)"
+  fi
+done < <(find "$VAULT" -name "*.md" \
+  -not -path "*/.obsidian/*" \
+  -not -path "*/.trash/*" \
+  -not -path "*/.stversions/*" \
+  -not -path "*/Resources/Templates/*" \
+  -print0)
+echo "- Total stubs (<5 lines): $stub_count"
+
+# Legacy junk tags
+echo ""
+echo "## Legacy/Junk Tags"
+junk_tags=0
+for pattern in "type/note" "area/projects" "area/personal" "area/work"; do
+  count=$(grep -rl "$pattern" "$VAULT" --include="*.md" 2>/dev/null | grep -v '.obsidian\|.trash\|.stversions' | wc -l)
+  if [ "$count" -gt 0 ]; then
+    echo "- '$pattern': $count files"
+    junk_tags=$((junk_tags + count))
+  fi
+done
+echo "- Total files with junk tags: $junk_tags"
+
+echo ""
+echo "---"
+echo "End of report"


### PR DESCRIPTION
## What

Two new skills in the `vault/` domain for Patsy, the Second Brain Curator.

### vault-curator
Core curation methodology:
- Frontmatter schema (created, type, status, tags, author)
- Tag taxonomy: `domain/` hierarchical + flat entity tags
- Wikilink conventions
- Inbox processing workflow
- Duplicate handling guidelines
- Briefing lifecycle (30-day archive rule)

### vault-linter
Scanning scripts:
- `vault-health.sh` — Full vault scan with stats
- `frontmatter-check.sh` — Missing/incomplete frontmatter
- `find-orphans.sh` — Notes with no incoming links
- `find-duplicates.sh` — Similar titles, cross-folder overlap

## How It Works

Patsy's `KNIGHT_SKILLS=vault` picks up everything in `vault/` automatically (plus `shared/`).