### PR TITLE
chore: add OSS release files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: 'bug: '
+labels: bug
+---
+
+## Describe the Bug
+A clear description of what the bug is.
+
+## To Reproduce
+Steps to reproduce:
+1. Apply manifest '...'
+2. Run command '...'
+3. See error
+
+## Expected Behavior
+What you expected to happen.
+
+## Environment
+- Kubernetes version: 
+- Operator version/image: 
+- Helm chart version: 
+- Cloud provider / distro: 
+
+## Logs
+```
+Paste relevant operator logs here
+```
+
+## Additional Context
+Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature Request
+about: Suggest a new feature
+title: 'feat: '
+labels: enhancement
+---
+
+## Problem
+What problem does this solve?
+
+## Proposed Solution
+Describe the feature you'd like.
+
+## Alternatives Considered
+Any alternative approaches you've considered.
+
+## Additional Context
+Any other context, diagrams, or examples.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## What
+
+Brief description of changes.
+
+## Why
+
+What problem does this solve? Link to issue if applicable.
+
+Closes #
+
+## How
+
+Key implementation details.
+
+## Testing
+
+- [ ] Unit tests added/updated
+- [ ] `make test` passes
+- [ ] `make manifests generate` run (if CRD changes)
+- [ ] Manual testing done (describe below)
+
+## Checklist
+
+- [ ] Code follows project conventions
+- [ ] Documentation updated (if applicable)
+- [ ] No breaking CRD changes (or migration path documented)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,52 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers at **derek.mackley@hotmail.com**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.8.x   | ✅ Current         |
+| < 0.8   | ❌ Not supported   |
+
+## Reporting a Vulnerability
+
+**Please do NOT report security vulnerabilities through public GitHub issues.**
+
+Instead, report them via email to: **derek.mackley@hotmail.com**
+
+Please include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+You should receive an initial response within **48 hours**. We will work with you to understand and address the issue before any public disclosure.
+
+## Security Considerations
+
+Round Table manages AI agents as Kubernetes pods. Key security areas:
+
+- **Pod isolation** — Knights run with restricted SecurityContexts and NetworkPolicies
+- **NATS authentication** — JetStream consumers use per-knight credentials
+- **Secret management** — Secrets are injected via ExternalSecrets/envFrom, never stored in CRDs
+- **RBAC** — Operator uses least-privilege ClusterRole; knights get namespace-scoped ServiceAccounts
+- **Ephemeral missions** — Auto-cleanup prevents resource leaks and reduces attack surface
+
+## Disclosure Policy
+
+- We follow [responsible disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure)
+- Fixes are released as patch versions
+- CVEs are filed when applicable
+- Credit is given to reporters (unless anonymity is requested)


### PR DESCRIPTION
## Open Source Release Preparation

Adds standard OSS files required for public release:

- **LICENSE** — Apache 2.0
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1
- **SECURITY.md** — Vulnerability disclosure policy
- **CONTRIBUTING.md** — Development setup and guidelines
- **Issue templates** — Bug report and feature request
- **PR template** — Standardized pull request format

Part of the Round Table ecosystem release prep.