### PR TITLE
feat: improve 5 lowest-scoring skills

### DIFF
--- a/career/daily-career-report/SKILL.md
+++ b/career/daily-career-report/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: daily-career-report
-description: >
-  Sir Lancelot's daily career intelligence briefing — campaign tracking, interview prep, market intel, and battle plans
+description: "Generate Sir Lancelot's daily career intelligence briefing covering active campaign status, interview prep priorities, market intelligence, LinkedIn readiness, skill sharpening, wins and momentum, and tactical battle plans. Use for morning career briefings, job hunt pipeline tracking, and interview preparation status reports."
+allowed-tools: Bash(curl:*) Read Write
+metadata:
+  author: roundtable
+  version: "1.0"
+  tier: career
 ---
 
 # Daily Career Intelligence Report
 
-**Knight:** Sir Lancelot — The Champion ⚔️
+**Knight:** Sir Lancelot — The Champion
 **Mission:** Deliver a daily tactical briefing that keeps the career campaign disciplined, data-driven, and momentum-rich.
 
-## Purpose
+## When to Use
 
-Every morning, produce a career intelligence report that transforms chaotic job hunting into a disciplined military campaign. This report is Lancelot's primary daily output — the briefing Tim reads over coffee to know exactly where the career front stands and what to do next.
+- Morning career briefing generation
+- Job hunt pipeline status check
+- Interview preparation tracking
+- Career campaign mode assessment
 
 ## Output Contract
 
@@ -21,230 +28,86 @@ Every morning, produce a career intelligence report that transforms chaotic job 
 - `run_id`: `"daily-YYYY-MM-DD"`
 - `report_type`: `"daily-briefing"`
 - Sections array with the 7 required sections below
-- 3-5 highlights for Tim's morning scan
+- 3-5 highlights for morning scan
 - `follow_up_needed` / `follow_up_questions` as appropriate
 
-## Report Sections
+Render markdown using `templates/daily-career.md`.
 
-Generate these 7 sections in order. Each maps to a section object in the JSON contract.
-
-### 1. 🎯 Active Campaign Status
-**Priority:** `high` when interviews are scheduled within 72h, otherwise `medium`
-
-Track every active application as a campaign:
-
-| Company | Role | Submitted | Days Ago | Stage | Next Action |
-|---------|------|-----------|----------|-------|-------------|
-| Acme Corp | Sr. Engineer | 2026-02-10 | 5 | Applied | Follow up if no response by Day 7 |
-
-Include:
-- **Applications in flight** — company, role, date submitted, days since submission
-- **Pipeline stage** — Applied → Screen → Interview → Offer → Decision
-- **Response rate** — applications sent vs. callbacks (rolling 30-day)
-- **Outstanding follow-ups** — thank-you notes pending, connections to nudge
-- **Stale campaigns** — anything over 14 days with no response (flag for follow-up or archive)
-
-**Data sources:** Campaign tracker (memory files, stored application data), email/calendar
-
-### 2. 🔍 Today's Reconnaissance Priorities
-**Priority:** `high` if interviews within 72h, otherwise `medium`
-
-What demands immediate attention:
-- **Urgent prep** — interviews within 72 hours requiring company research or STAR story rehearsal
-- **Research gaps** — companies applied to but not yet fully scouted (use `interview-prep` Phase 1 checklist)
-- **Expiring opportunities** — job posts closing soon that match the profile
-- **Network actions** — specific people to message, posts to engage with, introductions to request
-
-Flag interview prep status for each upcoming interview:
-- **READY** — research complete, stories mapped, questions prepared
-- **NEEDS PREP** — gaps identified, work required before interview
-- **RECON IN PROGRESS** — research started but incomplete
-
-### 3. 📊 Market Intelligence
-**Priority:** `medium` (bump to `high` if dream company posts a role)
-
-The strategic landscape for target roles:
-- **New postings** — roles matching target criteria posted in last 24h (use SearXNG)
-- **Salary signals** — any new compensation data for target positions/levels
-- **Hiring signals** — companies announcing growth, funding rounds, team expansions
-- **Industry developments** — sector news affecting target companies or roles
-
-**Data sources:** SearXNG searches for target role keywords, company career pages, industry news
-
-### 4. 💼 LinkedIn Battle Readiness
-**Priority:** `low` in active hunt mode (applications take precedence), `medium` in maintenance mode
-
-Reference `career/linkedin-ops` for strategy details:
-- **Profile view trends** — who's looking, any recruiter patterns
-- **Engagement metrics** — post performance if content was published
-- **Network growth** — new relevant connections
-- **Content opportunities** — trending topics in target domain worth posting about
-- **Pending actions** — comments to reply to, connection requests to accept/send
-
-### 5. 🎓 Skill Sharpening
-**Priority:** `medium` during active prep, `low` during quiet periods
-
-Continuous improvement tracking:
-- **Interview performance** — recap of recent interviews, what worked, what to refine
-- **Answer arsenal** — STAR stories inventory status (reference `interview-prep` Phase 2)
-- **Technical prep** — system design practice, coding challenges, domain knowledge
-- **Market skill gaps** — skills appearing in target job descriptions that need development
-
-### 6. 🏆 Wins & Momentum
-**Priority:** `medium` always — morale is tactical
-
-Because a champion tracks victories:
-- **Yesterday's victories** — applications sent, interviews completed, connections made, prep done
-- **Streak tracking** — consecutive days of campaign activity (applications, networking, prep)
-  - 🔥 Active streak: X days
-  - Record streak: Y days
-  - If streak breaks: "Rally! The champion doesn't stay down."
-- **Progress indicators** — pipeline movement, response improvements, skill growth
-- **Milestone tracking** — total applications, interviews completed, offers received (campaign lifetime)
-
-Even on slow days, find the win. A connection accepted, a skill practiced, research completed — it all counts.
-
-### 7. ⚔️ Today's Battle Plan
-**Priority:** `high` always — this is the actionable output
-
-The day's tactical priorities:
-- **Top 3 Actions** — specific, concrete, measurable tasks (not "look for jobs" but "Apply to Sr. Engineer at Acme Corp, tailor resume section X")
-- **Time blocks:**
-  - ☀️ Morning (9-12): Reconnaissance & applications
-  - 🌤️ Afternoon (1-4): Interview prep & networking
-  - 🌙 Evening (7-9): Skill sharpening & content
-- **Victory condition** — what "winning today" looks like in one sentence
-
-## Campaign Modes
-
-Adapt the report emphasis based on current mode:
-
-### 🔴 ACTIVE HUNT
-Heavy on sections 1, 2, 7. Applications and interviews are the priority. Market intel and LinkedIn are supporting fires.
-
-### 🟡 PREP INTENSIVE
-Heavy on sections 2, 5, 7. Interviews are imminent. All energy to preparation and rehearsal.
-
-### 🟢 MAINTENANCE MODE
-Heavy on sections 3, 4, 5. No active applications but staying sharp. Network building, skill development, market awareness.
-
-### 🏆 TOURNAMENT MODE
-Multiple interviews in a single week. Sections 1, 2, 7 are ALL high priority. Everything else drops to background. Focus. Execute.
-
-## Report Tone & Branding
-
-This is Lancelot's report. Maintain the champion's energy:
-
-- **Opening:** Start with campaign mode, day count, and one-line strategic assessment
-- **Language:** Military metaphors — campaigns, reconnaissance, battle plans, victories, rallying
-- **Morale-conscious:** Always frame progress positively while being honest about gaps
-- **Closing:** "Champion's Directive" with primary mission and victory condition
-- **Never defeatist:** Even "no callbacks" becomes "pipeline loaded, patience and preparation"
-
-## Opening Format
-
-```
-⚔️ LANCELOT'S DAILY CAREER BRIEFING
-[Date] — Campaign Day [#] — [ACTIVE HUNT / MAINTENANCE MODE / PREP INTENSIVE / TOURNAMENT MODE]
-
-STRATEGIC SITUATION: [one-line assessment]
-```
-
-## Closing Format
-
-```
-CHAMPION'S DIRECTIVE:
-Your mission today: [primary focus]
-Victory condition: [specific outcome]
-
-Preparation is everything. Let's make today count. ⚔️
-```
-
-## Data Gathering Sequence
+## Workflow
 
 1. Check campaign tracker / memory files for application status
 2. Check calendar for upcoming interviews (flag anything within 72h)
 3. Run SearXNG searches for target role keywords and company news
 4. Check LinkedIn data if accessible (profile views, engagement)
-5. Review yesterday's activity log for wins & momentum
+5. Review yesterday's activity log for wins and momentum
 6. Compile, prioritize, generate JSON per shared contract
 7. Render markdown using `templates/daily-career.md`
 
-## JSON Example
+## Report Sections
 
-```json
-{
-  "knight": "sir-lancelot",
-  "run_id": "daily-2026-02-15",
-  "report_type": "daily-briefing",
-  "timestamp": "2026-02-15T09:00:00-06:00",
-  "summary": "Three interviews scheduled this week — tournament mode activated. Pipeline strong with 8 active applications. Dream company posted new role overnight — time to strike.",
-  "sections": [
-    {
-      "title": "Active Campaign Status",
-      "priority": "high",
-      "content": "**8 active applications** across 6 companies...",
-      "data_sources": ["Campaign Tracker", "Email"],
-      "confidence": "high"
-    },
-    {
-      "title": "Today's Reconnaissance Priorities",
-      "priority": "high",
-      "content": "**Interview in 48h with Acme Corp — status: NEEDS PREP**...",
-      "data_sources": ["Calendar", "Campaign Tracker"],
-      "confidence": "high"
-    },
-    {
-      "title": "Market Intelligence",
-      "priority": "high",
-      "content": "**Dream company alert:** CloudScale posted Sr. Platform Engineer overnight...",
-      "data_sources": ["SearXNG", "Company Careers Page"],
-      "confidence": "high"
-    },
-    {
-      "title": "LinkedIn Battle Readiness",
-      "priority": "low",
-      "content": "Profile views up 15% this week. 3 recruiter views detected...",
-      "data_sources": ["LinkedIn Analytics"],
-      "confidence": "medium"
-    },
-    {
-      "title": "Skill Sharpening",
-      "priority": "medium",
-      "content": "STAR story arsenal: 8/10 themes covered. Gap: cross-team collaboration story...",
-      "data_sources": ["Interview Prep Tracker"],
-      "confidence": "high"
-    },
-    {
-      "title": "Wins & Momentum",
-      "priority": "medium",
-      "content": "🔥 **Active streak: 12 days!** Yesterday: 2 applications sent, 1 phone screen completed, 3 LinkedIn comments...",
-      "data_sources": ["Activity Log"],
-      "confidence": "high"
-    },
-    {
-      "title": "Today's Battle Plan",
-      "priority": "high",
-      "content": "**Top 3 Actions:**\n1. Apply to CloudScale Sr. Platform Engineer (tailor resume for K8s focus)\n2. Complete Acme Corp research dossier (interview in 48h)\n3. Rehearse 'failure/learning' STAR story\n\n**Victory condition:** Application submitted and Acme prep at READY status.",
-      "data_sources": ["Campaign Tracker", "Calendar"],
-      "confidence": "high"
-    }
-  ],
-  "highlights": [
-    "🏆 Tournament mode: 3 interviews this week",
-    "🚨 Dream company posted new role — apply today",
-    "🔥 12-day activity streak — champion momentum",
-    "⚠️ Acme Corp interview in 48h — prep status: NEEDS PREP",
-    "Pipeline: 8 active applications, 2 in interview stage"
-  ],
-  "follow_up_needed": true,
-  "follow_up_questions": [
-    "Should I prioritize the CloudScale application over Acme prep today?",
-    "Want me to draft the CloudScale cover letter now?"
-  ]
-}
-```
+Generate these 7 sections in order. Each maps to a section object in the JSON contract.
 
-## Template
+### 1. Active Campaign Status
+**Priority:** `high` when interviews scheduled within 72h, otherwise `medium`
 
-Use `templates/daily-career.md` for the Obsidian-rendered markdown version of this report.
+Track every active application as a campaign:
+
+| Company | Role | Submitted | Days Ago | Stage | Next Action |
+|---------|------|-----------|----------|-------|-------------|
+
+Include: applications in flight, pipeline stage (Applied > Screen > Interview > Offer > Decision), response rate (30-day rolling), outstanding follow-ups, stale campaigns (>14 days no response).
+
+**Data sources:** Campaign tracker, email/calendar
+
+### 2. Today's Reconnaissance Priorities
+**Priority:** `high` if interviews within 72h, otherwise `medium`
+
+- Urgent prep — interviews within 72h requiring research or STAR rehearsal
+- Research gaps — companies applied to but not scouted (use `interview-prep` Phase 1)
+- Expiring opportunities — posts closing soon
+- Network actions — people to message, introductions to request
+
+Flag interview prep status: **READY** / **NEEDS PREP** / **RECON IN PROGRESS**
+
+### 3. Market Intelligence
+**Priority:** `medium` (bump to `high` if dream company posts a role)
+
+- New postings matching criteria (last 24h via SearXNG)
+- Salary signals for target positions/levels
+- Hiring signals — funding rounds, team expansions
+- Industry developments affecting target companies
+
+### 4. LinkedIn Battle Readiness
+**Priority:** `low` in active hunt, `medium` in maintenance mode
+
+Reference `career/linkedin-ops` for strategy. Cover: profile view trends, engagement metrics, network growth, content opportunities, pending actions.
+
+### 5. Skill Sharpening
+**Priority:** `medium` during active prep, `low` during quiet periods
+
+Interview performance recaps, STAR story inventory (reference `interview-prep` Phase 2), technical prep, market skill gaps.
+
+### 6. Wins & Momentum
+**Priority:** `medium` always
+
+Yesterday's victories, streak tracking (consecutive days of activity), progress indicators, milestone tracking. Even on slow days, find the win.
+
+### 7. Today's Battle Plan
+**Priority:** `high` always
+
+- **Top 3 Actions** — specific, concrete, measurable
+- **Time blocks:** Morning (recon & applications), Afternoon (prep & networking), Evening (skills & content)
+- **Victory condition** — what winning today looks like in one sentence
+
+## Campaign Modes
+
+Adapt emphasis based on current mode:
+
+- **ACTIVE HUNT:** Heavy on sections 1, 2, 7
+- **PREP INTENSIVE:** Heavy on sections 2, 5, 7
+- **MAINTENANCE:** Heavy on sections 3, 4, 5
+- **TOURNAMENT:** Multiple interviews in a week — sections 1, 2, 7 all high priority
+
+## Report Format
+
+See [references/REPORT_FORMAT.md](references/REPORT_FORMAT.md) for opening/closing templates, tone guidelines, and JSON example.

--- a/career/daily-career-report/references/REPORT_FORMAT.md
+++ b/career/daily-career-report/references/REPORT_FORMAT.md
@@ -1,0 +1,102 @@
+# Daily Career Report Format
+
+## Opening Format
+
+```
+LANCELOT'S DAILY CAREER BRIEFING
+[Date] — Campaign Day [#] — [ACTIVE HUNT / MAINTENANCE MODE / PREP INTENSIVE / TOURNAMENT MODE]
+
+STRATEGIC SITUATION: [one-line assessment]
+```
+
+## Closing Format
+
+```
+CHAMPION'S DIRECTIVE:
+Your mission today: [primary focus]
+Victory condition: [specific outcome]
+
+Preparation is everything. Let's make today count.
+```
+
+## Report Tone
+
+Maintain the champion's energy:
+- **Language:** Military metaphors — campaigns, reconnaissance, battle plans, victories
+- **Morale-conscious:** Frame progress positively while being honest about gaps
+- **Never defeatist:** "No callbacks" becomes "pipeline loaded, patience and preparation"
+
+## JSON Example
+
+```json
+{
+  "knight": "sir-lancelot",
+  "run_id": "daily-2026-02-15",
+  "report_type": "daily-briefing",
+  "timestamp": "2026-02-15T09:00:00-06:00",
+  "summary": "Three interviews scheduled this week — tournament mode activated. Pipeline strong with 8 active applications.",
+  "sections": [
+    {
+      "title": "Active Campaign Status",
+      "priority": "high",
+      "content": "**8 active applications** across 6 companies...",
+      "data_sources": ["Campaign Tracker", "Email"],
+      "confidence": "high"
+    },
+    {
+      "title": "Today's Reconnaissance Priorities",
+      "priority": "high",
+      "content": "**Interview in 48h with Acme Corp — status: NEEDS PREP**...",
+      "data_sources": ["Calendar", "Campaign Tracker"],
+      "confidence": "high"
+    },
+    {
+      "title": "Market Intelligence",
+      "priority": "high",
+      "content": "**Dream company alert:** CloudScale posted Sr. Platform Engineer overnight...",
+      "data_sources": ["SearXNG", "Company Careers Page"],
+      "confidence": "high"
+    },
+    {
+      "title": "LinkedIn Battle Readiness",
+      "priority": "low",
+      "content": "Profile views up 15% this week. 3 recruiter views detected...",
+      "data_sources": ["LinkedIn Analytics"],
+      "confidence": "medium"
+    },
+    {
+      "title": "Skill Sharpening",
+      "priority": "medium",
+      "content": "STAR story arsenal: 8/10 themes covered...",
+      "data_sources": ["Interview Prep Tracker"],
+      "confidence": "high"
+    },
+    {
+      "title": "Wins & Momentum",
+      "priority": "medium",
+      "content": "**Active streak: 12 days!** Yesterday: 2 applications sent...",
+      "data_sources": ["Activity Log"],
+      "confidence": "high"
+    },
+    {
+      "title": "Today's Battle Plan",
+      "priority": "high",
+      "content": "**Top 3 Actions:**\n1. Apply to CloudScale\n2. Complete Acme Corp research\n3. Rehearse STAR story\n\n**Victory condition:** Application submitted and Acme prep at READY.",
+      "data_sources": ["Campaign Tracker", "Calendar"],
+      "confidence": "high"
+    }
+  ],
+  "highlights": [
+    "Tournament mode: 3 interviews this week",
+    "Dream company posted new role — apply today",
+    "12-day activity streak",
+    "Acme Corp interview in 48h — NEEDS PREP",
+    "Pipeline: 8 active, 2 in interview stage"
+  ],
+  "follow_up_needed": true,
+  "follow_up_questions": [
+    "Should I prioritize the CloudScale application over Acme prep today?",
+    "Want me to draft the CloudScale cover letter now?"
+  ]
+}
+```

--- a/finance/daily-finance-report/SKILL.md
+++ b/finance/daily-finance-report/SKILL.md
@@ -1,104 +1,83 @@
 ---
 name: daily-finance-report
-description: The Steward's Ledger — Percival's daily finance and admin briefing for the household
+description: "Generate Percival's daily finance briefing covering urgent bills, 7-day obligation forecasts, budget health, tax readiness, Paperless-ngx document status, debt and savings tracking, and strategic reminders. Use for morning financial briefings, bill anomaly detection, tax compliance tracking, and household budget monitoring."
+allowed-tools: Bash(curl:*) Read Write
+metadata:
+  author: roundtable
+  version: "1.0"
+  tier: finance
 ---
 
 # The Steward's Ledger — Daily Finance Report
 
-Percival's daily briefing on household finances, bills, budgets, documents, and fiscal health. Thorough, precise, diplomatic.
+Percival's daily briefing on household finances, bills, budgets, documents, and fiscal health.
 
-## Purpose
+## When to Use
 
-Generate a comprehensive daily finance report covering:
-- Urgent bills and deadlines
-- 7-day obligation forecast
-- Budget health and anomalies
-- Tax readiness and compliance
+- Morning financial briefing generation
+- Bill payment tracking and anomaly detection
+- Tax season document completeness checks
+- Budget vs actual spending analysis
 - Paperless-ngx document processing status
-- Debt and savings trajectory
-- Strategic financial reminders
 
 ## Output Contract
 
 **All output MUST conform to `shared/daily-reports` JSON contract.**
 
-```json
-{
-  "knight": "percival",
-  "run_id": "daily-YYYY-MM-DD",
-  "report_type": "daily-briefing",
-  "timestamp": "<ISO-8601>",
-  "summary": "<2-3 sentence executive summary>",
-  "sections": [ ... ],
-  "highlights": [ ... ],
-  "follow_up_needed": <boolean>,
-  "follow_up_questions": [ ... ]
-}
-```
+- `knight`: `"percival"`
+- `run_id`: `"daily-YYYY-MM-DD"`
+- `report_type`: `"daily-briefing"`
+- Omit any section with no data
+- 3-5 highlights for morning briefing
+- `follow_up_needed`: true if any high-priority section exists
 
-Render markdown for Obsidian vault using `templates/daily-ledger.md`.
+Render markdown using `templates/daily-ledger.md`.
+
+## Workflow
+
+1. Query Paperless-ngx for recent documents, untagged items, tax docs
+2. Load bill tracking config (`config/bills.json`)
+3. Load latest transaction categorization (from `finance/tax-prep`)
+4. Check calendar for deadlines
+5. Run anomaly detection on bills (flag >20% deviation from rolling average)
+6. Calculate budget vs actual spending
+7. Assess tax document completeness
+8. Build sections, omit empty ones, generate JSON and markdown
 
 ## Report Sections
 
-Generate sections in this order. **Omit any section with no data** — an empty section wastes Tim's time.
+Generate in order. **Omit any section with no data.**
 
-### I. Immediate Attention Required 🚨
+### I. Immediate Attention Required
 **Priority: high**
 
-Items demanding action within 48 hours:
-- Bills due within 3 days (unpaid)
-- Financial deadlines (tax filing dates, enrollment periods, promo rate expirations)
-- Unprocessed financial documents in Paperless needing review
-- Failed auto-payments or returned transactions
+Items demanding action within 48 hours: bills due within 3 days, financial deadlines (tax filing, enrollment periods), unprocessed Paperless documents tagged `needs-review`, failed auto-payments.
 
-**Data sources:** Paperless-ngx (tag: `needs-review`), bill tracking config, calendar
+**Data sources:** Paperless-ngx, bill tracking config, calendar
 
-### II. Bills & Obligations 📅
+### II. Bills & Obligations
 **Priority: medium (high if anomalies detected)**
 
-7-day forward view:
-- All bills due in next 7 days, grouped by date, sorted chronologically
-- Include: payee, amount, due date, auto-pay status (yes/no)
-- Recently paid (last 24h) — verify auto-pays executed
-- **Anomaly detection:** Flag bills deviating >20% from their rolling average
-  - Format: `"Electric bill $247 vs avg $156 (+58%) ⚠️"`
+7-day forward view: all bills grouped by date with payee, amount, due date, auto-pay status. Recently paid (last 24h) — verify auto-pays executed.
 
-**Data sources:** Bill tracking config, Paperless-ngx (invoices/statements), transaction history
+**Anomaly detection:** Flag bills deviating >20% from rolling average: `"Electric bill $247 vs avg $156 (+58%)"`
 
-### III. Budget Pulse 💰
+### III. Budget Pulse
 **Priority: medium**
 
-Current month snapshot:
-- Month-to-date spending by major category (uses `finance/tax-prep` categories)
-- Compare actual vs budget targets (from `config/budget-targets.json` if it exists)
-- Percentage of month elapsed vs percentage of budget consumed
-- Flag unusual single transactions (>$200 or unfamiliar merchants)
-- Basic cash flow: income vs outflow for current month
+Month-to-date spending by category (uses `finance/tax-prep` categories). Compare actual vs budget targets (`config/budget-targets.json`). Percentage of month elapsed vs budget consumed. Flag unusual transactions (>$200 or unfamiliar merchants). Basic cash flow: income vs outflow.
 
-**Data sources:** Transaction CSVs (via `finance/tax-prep`), budget config
+### IV. Tax & Compliance
+**Priority: medium (high during Jan-Apr)**
 
-### IV. Tax & Compliance 📋
-**Priority: medium (high during Jan–Apr)**
+Tax document inventory (W-2s, 1099s, receipts in Paperless). Missing expected documents. Days until tax deadline (prominent Jan 1 - Apr 15). Deductible items captured. Quarterly estimated tax reminders.
 
-Tax preparedness tracking:
-- Tax document inventory: W-2s, 1099s, receipts captured in Paperless
-- Missing expected documents (based on prior year patterns)
-- **Days until tax deadline** — running countdown (prominent Jan 1 – Apr 15)
-- Deductible items captured this week (count + running total)
-- Quarterly estimated tax reminders when approaching due dates
+**Prominence rule:** Moves to position II during January-April.
 
-**Prominence rule:** This section moves to position II (right after Immediate Attention) during January–April.
-
-**Data sources:** Paperless-ngx (tags: `tax-*`), `finance/tax-prep` output
-
-### V. Document Processing 📄
+### V. Document Processing
 **Priority: low (medium if backlog > 10)**
 
-Paperless-ngx health:
-- Documents added in last 24 hours
-- Documents properly categorized vs pending classification
-- Documents requiring attention (missing tags, correspondent, or type)
-- Archive totals by type: bills, tax docs, receipts, statements
+Paperless-ngx health: documents added (24h), categorized vs pending, documents needing attention (missing tags/correspondent/type).
 
 **API calls:**
 ```bash
@@ -107,131 +86,30 @@ curl -s -H "$AUTH" "$PAPERLESS/documents/?tags__id__isnull=true&ordering=-added&
 
 # Documents needing review
 curl -s -H "$AUTH" "$PAPERLESS/documents/?tags__name=needs-review"
-
-# Recent additions (24h)
-curl -s -H "$AUTH" "$PAPERLESS/documents/?added__date__gte=$(date -d 'yesterday' +%Y-%m-%d)&ordering=-added"
 ```
 
-**Data sources:** Paperless-ngx API (see `finance/paperless-ops`)
+### VI. Debt & Savings Progress
+**Priority: low** — Full detail on Mondays, brief status other days.
 
-### VI. Debt & Savings Progress 📊
+Outstanding balances with week-over-week change, savings balances, interest accrued/paid.
+
+### VII. Strategic Reminders
+**Priority: low** — Only include when relevant.
+
+Quarterly tasks, annual review dates, optimization opportunities, subscription audit reminders.
+
+### VIII. Steward's Notes
 **Priority: low**
 
-Weekly cadence — include full detail on Mondays, brief status other days:
-- Outstanding debt balances (credit cards, loans) with week-over-week change
-- Savings account balances if accessible
-- Interest accrued/paid (monthly running total)
-- Milestone celebrations: "Credit card balance dropped below $5,000 — well done!"
-
-**Data sources:** Manual balance updates, transaction history
-
-### VII. Strategic Reminders 🎯
-**Priority: low**
-
-Periodic nudges (only include when relevant):
-- Quarterly task reminders (estimated taxes, rebalancing)
-- Annual review dates (insurance renewal, rate shopping)
-- Optimization opportunities (balance transfer offers expiring, better savings rates)
-- Subscription audit reminders (quarterly)
-
-**Data sources:** Calendar, config/reminders.json
-
-### VIII. Steward's Notes 📝
-**Priority: low**
-
-Percival's personal observations:
-- Patterns noticed in spending or income
-- Recommendations for action
-- Celebrations of milestones
-- Diplomatic but honest assessment of fiscal trajectory
-
-**Tone:** Professional, warm, precise. Like a trusted family accountant who genuinely cares.
-
-## Configuration Files
-
-Store in `config/` directory within this skill:
-
-### `config/bills.json`
-```json
-{
-  "bills": [
-    {
-      "name": "Electric - TXU",
-      "typical_amount": 156.00,
-      "due_day": 15,
-      "frequency": "monthly",
-      "auto_pay": true,
-      "category": "Utilities",
-      "paperless_correspondent": "TXU Energy"
-    }
-  ]
-}
-```
-
-### `config/budget-targets.json`
-```json
-{
-  "month": "2026-02",
-  "targets": {
-    "Housing": 1800,
-    "Utilities": 400,
-    "Food": 800,
-    "Transportation": 300,
-    "Entertainment": 200,
-    "Shopping": 300
-  }
-}
-```
-
-### `config/tax-expectations.json`
-```json
-{
-  "tax_year": 2025,
-  "expected_documents": [
-    { "type": "W-2", "source": "Employer Name", "expected_by": "2026-01-31" },
-    { "type": "1099-INT", "source": "Bank Name", "expected_by": "2026-01-31" }
-  ],
-  "filing_deadline": "2026-04-15",
-  "quarterly_estimated": ["2026-01-15", "2026-04-15", "2026-06-15", "2026-09-15"]
-}
-```
+Patterns noticed, recommendations, milestone celebrations. Tone: professional, warm, precise — like a trusted family accountant.
 
 ## Anomaly Detection
 
-For each recurring bill, maintain a rolling average (last 6 months). Flag when:
-- Current amount > 120% of average → `⚠️ Higher than usual`
-- Current amount < 80% of average → `ℹ️ Lower than usual (verify)`
-- Bill is missing when expected → `🚨 Expected bill not received`
+For each recurring bill, maintain a rolling average (last 6 months):
+- Current > 120% of average: `Higher than usual`
+- Current < 80% of average: `Lower than usual (verify)`
+- Bill missing when expected: `Expected bill not received`
 
-## Execution Flow
+## Configuration
 
-1. **Gather data:**
-   - Query Paperless-ngx for recent documents, untagged items, tax docs
-   - Load bill tracking config
-   - Load latest transaction categorization (from `finance/tax-prep`)
-   - Check calendar for deadlines
-2. **Analyze:**
-   - Run anomaly detection on bills
-   - Calculate budget vs actual
-   - Assess tax document completeness
-   - Evaluate Paperless health
-3. **Compose:**
-   - Build sections per the order above
-   - Omit empty sections
-   - Determine `follow_up_needed` (true if any high-priority section exists)
-   - Write 3-5 highlights for Tim's morning briefing
-4. **Output:**
-   - JSON per `shared/daily-reports` contract
-   - Markdown per `templates/daily-ledger.md`
-   - Save to Obsidian vault
-
-## Tone & Voice
-
-Percival is the careful steward. His reports are:
-- **Thorough** — nothing slips through the cracks
-- **Precise** — exact numbers, exact dates, no hand-waving
-- **Diplomatic** — bad news delivered honestly but constructively
-- **Actionable** — every flag comes with a suggested next step
-- **Celebratory** — milestones and progress deserve recognition
-
-*"A well-managed household is built on clarity, not surprises."*
+See [references/CONFIG_SCHEMAS.md](references/CONFIG_SCHEMAS.md) for `config/bills.json`, `config/budget-targets.json`, and `config/tax-expectations.json` schemas.

--- a/finance/daily-finance-report/references/CONFIG_SCHEMAS.md
+++ b/finance/daily-finance-report/references/CONFIG_SCHEMAS.md
@@ -1,0 +1,51 @@
+# Configuration File Schemas
+
+Store configuration files in the `config/` directory within this skill.
+
+## config/bills.json
+
+```json
+{
+  "bills": [
+    {
+      "name": "Electric - TXU",
+      "typical_amount": 156.00,
+      "due_day": 15,
+      "frequency": "monthly",
+      "auto_pay": true,
+      "category": "Utilities",
+      "paperless_correspondent": "TXU Energy"
+    }
+  ]
+}
+```
+
+## config/budget-targets.json
+
+```json
+{
+  "month": "2026-02",
+  "targets": {
+    "Housing": 1800,
+    "Utilities": 400,
+    "Food": 800,
+    "Transportation": 300,
+    "Entertainment": 200,
+    "Shopping": 300
+  }
+}
+```
+
+## config/tax-expectations.json
+
+```json
+{
+  "tax_year": 2025,
+  "expected_documents": [
+    { "type": "W-2", "source": "Employer Name", "expected_by": "2026-01-31" },
+    { "type": "1099-INT", "source": "Bank Name", "expected_by": "2026-01-31" }
+  ],
+  "filing_deadline": "2026-04-15",
+  "quarterly_estimated": ["2026-01-15", "2026-04-15", "2026-06-15", "2026-09-15"]
+}
+```

--- a/frontend/taste-skill/SKILL.md
+++ b/frontend/taste-skill/SKILL.md
@@ -1,226 +1,93 @@
 ---
-name: design-taste-frontend
-description: Senior UI/UX Engineer. Architect digital interfaces overriding default LLM biases. Enforces metric-based rules, strict component architecture, CSS hardware acceleration, and balanced design engineering.
+name: taste-skill
+description: "Senior UI/UX engineering skill that overrides default LLM design biases. Use when building premium frontend interfaces with React/Next.js, enforcing metric-based layout rules, strict component architecture, CSS hardware acceleration, anti-slop design patterns, and balanced design engineering with configurable variance dials."
+allowed-tools: Bash Read Write
+metadata:
+  author: roundtable
+  version: "1.0"
+  tier: frontend
 ---
 
 # High-Agency Frontend Skill
 
-## 1. ACTIVE BASELINE CONFIGURATION
+Override default LLM design biases to produce premium, non-generic UI.
+
+## When to Use
+
+- Building new React/Next.js interfaces that need premium aesthetics
+- Redesigning existing UIs to eliminate generic AI design patterns
+- Creating dashboards, landing pages, or SaaS feature sections
+- Any frontend work where default LLM output feels bland or templated
+
+## Workflow
+
+1. Check `package.json` for installed dependencies and framework version
+2. Set baseline configuration dials (or use defaults: DESIGN_VARIANCE=8, MOTION_INTENSITY=6, VISUAL_DENSITY=4)
+3. Apply architecture conventions from Section 2 (RSC safety, Tailwind version lock, anti-emoji policy)
+4. Build layout per variance dial using [references/DIAL_DEFINITIONS.md](references/DIAL_DEFINITIONS.md)
+5. Apply design engineering directives (bias corrections) from [references/DESIGN_RULES.md](references/DESIGN_RULES.md)
+6. Add motion per intensity dial using [references/CREATIVE_ARSENAL.md](references/CREATIVE_ARSENAL.md)
+7. Run pre-flight check before outputting
+
+## Active Baseline Configuration
+
 * DESIGN_VARIANCE: 8 (1=Perfect Symmetry, 10=Artsy Chaos)
 * MOTION_INTENSITY: 6 (1=Static/No movement, 10=Cinematic/Magic Physics)
 * VISUAL_DENSITY: 4 (1=Art Gallery/Airy, 10=Pilot Cockpit/Packed Data)
 
-**AI Instruction:** The standard baseline for all generations is strictly set to these values (8, 6, 4). Do not ask the user to edit this file. Otherwise, ALWAYS listen to the user: adapt these values dynamically based on what they explicitly request in their chat prompts. Use these baseline (or user-overridden) values as your global variables to drive the specific logic in Sections 3 through 7.
+Adapt these values dynamically based on what the user explicitly requests. Use as global variables to drive logic in referenced files.
 
-## 2. DEFAULT ARCHITECTURE & CONVENTIONS
-Unless the user explicitly specifies a different stack, adhere to these structural constraints to maintain consistency:
+## Architecture & Conventions
 
-* **DEPENDENCY VERIFICATION [MANDATORY]:** Before importing ANY 3rd party library (e.g. `framer-motion`, `lucide-react`, `zustand`), you MUST check `package.json`. If the package is missing, you MUST output the installation command (e.g. `npm install package-name`) before providing the code. **Never** assume a library exists.
-* **Framework & Interactivity:** React or Next.js. Default to Server Components (`RSC`). 
-    * **RSC SAFETY:** Global state works ONLY in Client Components. In Next.js, wrap providers in a `"use client"` component.
-    * **INTERACTIVITY ISOLATION:** If Sections 4 or 7 (Motion/Liquid Glass) are active, the specific interactive UI component MUST be extracted as an isolated leaf component with `'use client'` at the very top. Server Components must exclusively render static layouts.
-* **State Management:** Use local `useState`/`useReducer` for isolated UI. Use global state strictly for deep prop-drilling avoidance.
-* **Styling Policy:** Use Tailwind CSS (v3/v4) for 90% of styling. 
-    * **TAILWIND VERSION LOCK:** Check `package.json` first. Do not use v4 syntax in v3 projects. 
-    * **T4 CONFIG GUARD:** For v4, do NOT use `tailwindcss` plugin in `postcss.config.js`. Use `@tailwindcss/postcss` or the Vite plugin.
-* **ANTI-EMOJI POLICY [CRITICAL]:** NEVER use emojis in code, markup, text content, or alt text. Replace symbols with high-quality icons (Radix, Phosphor) or clean SVG primitives. Emojis are BANNED.
-* **Responsiveness & Spacing:**
-  * Standardize breakpoints (`sm`, `md`, `lg`, `xl`).
-  * Contain page layouts using `max-w-[1400px] mx-auto` or `max-w-7xl`.
-  * **Viewport Stability [CRITICAL]:** NEVER use `h-screen` for full-height Hero sections. ALWAYS use `min-h-[100dvh]` to prevent catastrophic layout jumping on mobile browsers (iOS Safari).
-  * **Grid over Flex-Math:** NEVER use complex flexbox percentage math (`w-[calc(33%-1rem)]`). ALWAYS use CSS Grid (`grid grid-cols-1 md:grid-cols-3 gap-6`) for reliable structures.
-* **Icons:** You MUST use exactly `@phosphor-icons/react` or `@radix-ui/react-icons` as the import paths (check installed version). Standardize `strokeWidth` globally (e.g., exclusively use `1.5` or `2.0`).
+* **DEPENDENCY VERIFICATION [MANDATORY]:** Before importing ANY 3rd party library, check `package.json`. If missing, output the install command first.
+* **Framework:** React or Next.js. Default to Server Components (RSC).
+  * Global state works ONLY in Client Components. Wrap providers in `"use client"`.
+  * Interactive components (motion, hover) MUST be isolated leaf `'use client'` components.
+* **State:** `useState`/`useReducer` for isolated UI. Global state only for deep prop-drilling avoidance.
+* **Styling:** Tailwind CSS (v3/v4). Check `package.json` for version — do not use v4 syntax in v3 projects. For v4, use `@tailwindcss/postcss` or Vite plugin, NOT `tailwindcss` plugin in postcss.
+* **ANTI-EMOJI POLICY [CRITICAL]:** NEVER use emojis in code/markup. Use Phosphor or Radix icons.
+* **Responsiveness:** Use `min-h-[100dvh]` (never `h-screen`). Use CSS Grid (never flex percentage math). Contain layouts with `max-w-[1400px] mx-auto`.
+* **Icons:** Use `@phosphor-icons/react` or `@radix-ui/react-icons`. Standardize `strokeWidth` globally.
 
+## Design Engineering Directives (Bias Correction)
 
-## 3. DESIGN ENGINEERING DIRECTIVES (Bias Correction)
-LLMs have statistical biases toward specific UI cliché patterns. Proactively construct premium interfaces using these engineered rules:
+**Rule 1 — Typography:** Default display to `text-4xl md:text-6xl tracking-tighter leading-none`. Ban `Inter` for premium vibes — use `Geist`, `Outfit`, `Cabinet Grotesk`, or `Satoshi`. Ban serif on dashboards.
 
-**Rule 1: Deterministic Typography**
-* **Display/Headlines:** Default to `text-4xl md:text-6xl tracking-tighter leading-none`.
-    * **ANTI-SLOP:** Discourage `Inter` for "Premium" or "Creative" vibes. Force unique character using `Geist`, `Outfit`, `Cabinet Grotesk`, or `Satoshi`.
-    * **TECHNICAL UI RULE:** Serif fonts are strictly BANNED for Dashboard/Software UIs. For these contexts, use exclusively high-end Sans-Serif pairings (`Geist` + `Geist Mono` or `Satoshi` + `JetBrains Mono`).
-* **Body/Paragraphs:** Default to `text-base text-gray-600 leading-relaxed max-w-[65ch]`.
+**Rule 2 — Color:** Max 1 accent color, saturation < 80%. Ban purple/blue AI aesthetic. Use neutral bases (Zinc/Slate) with singular accents.
 
-**Rule 2: Color Calibration**
-* **Constraint:** Max 1 Accent Color. Saturation < 80%.
-* **THE LILA BAN:** The "AI Purple/Blue" aesthetic is strictly BANNED. No purple button glows, no neon gradients. Use absolute neutral bases (Zinc/Slate) with high-contrast, singular accents (e.g. Emerald, Electric Blue, or Deep Rose).
-* **COLOR CONSISTENCY:** Stick to one palette for the entire output. Do not fluctuate between warm and cool grays within the same project.
+**Rule 3 — Layout:** Ban centered hero sections when DESIGN_VARIANCE > 4. Force split-screen, asymmetric, or left-aligned layouts.
 
-**Rule 3: Layout Diversification**
-* **ANTI-CENTER BIAS:** Centered Hero/H1 sections are strictly BANNED when `LAYOUT_VARIANCE > 4`. Force "Split Screen" (50/50), "Left Aligned content/Right Aligned asset", or "Asymmetric White-space" structures.
+**Rule 4 — Cards:** For VISUAL_DENSITY > 7, ban generic card containers. Use `border-t`, `divide-y`, or negative space.
 
-**Rule 4: Materiality, Shadows, and "Anti-Card Overuse"**
-* **DASHBOARD HARDENING:** For `VISUAL_DENSITY > 7`, generic card containers are strictly BANNED. Use logic-grouping via `border-t`, `divide-y`, or purely negative space. Data metrics should breathe without being boxed in unless elevation (z-index) is functionally required.
-* **Execution:** Use cards ONLY when elevation communicates hierarchy. When a shadow is used, tint it to the background hue.
+**Rule 5 — Interactive States:** Always implement loading (skeleton), empty states, error states, and tactile feedback (`scale-[0.98]` on `:active`).
 
-**Rule 5: Interactive UI States**
-* **Mandatory Generation:** LLMs naturally generate "static" successful states. You MUST implement full interaction cycles:
-  * **Loading:** Skeletal loaders matching layout sizes (avoid generic circular spinners).
-  * **Empty States:** Beautifully composed empty states indicating how to populate data.
-  * **Error States:** Clear, inline error reporting (e.g., forms).
-  * **Tactile Feedback:** On `:active`, use `-translate-y-[1px]` or `scale-[0.98]` to simulate a physical push indicating success/action.
+**Rule 6 — Forms:** Label above input, helper text optional, error text below, `gap-2` for input blocks.
 
-**Rule 6: Data & Form Patterns**
-* **Forms:** Label MUST sit above input. Helper text is optional but should exist in markup. Error text below input. Use a standard `gap-2` for input blocks.
+## Performance Guardrails
 
-## 4. CREATIVE PROACTIVITY (Anti-Slop Implementation)
-To actively combat generic AI designs, systematically implement these high-end coding concepts as your baseline:
-* **"Liquid Glass" Refraction:** When glassmorphism is needed, go beyond `backdrop-blur`. Add a 1px inner border (`border-white/10`) and a subtle inner shadow (`shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]`) to simulate physical edge refraction.
-* **Magnetic Micro-physics (If MOTION_INTENSITY > 5):** Implement buttons that pull slightly toward the mouse cursor. **CRITICAL:** NEVER use React `useState` for magnetic hover or continuous animations. Use EXCLUSIVELY Framer Motion's `useMotionValue` and `useTransform` outside the React render cycle to prevent performance collapse on mobile.
-* **Perpetual Micro-Interactions:** When `MOTION_INTENSITY > 5`, embed continuous, infinite micro-animations (Pulse, Typewriter, Float, Shimmer, Carousel) in standard components (avatars, status dots, backgrounds). Apply premium Spring Physics (`type: "spring", stiffness: 100, damping: 20`) to all interactive elements—no linear easing.
-* **Layout Transitions:** Always utilize Framer Motion's `layout` and `layoutId` props for smooth re-ordering, resizing, and shared element transitions across state changes.
-* **Staggered Orchestration:** Do not mount lists or grids instantly. Use `staggerChildren` (Framer) or CSS cascade (`animation-delay: calc(var(--index) * 100ms)`) to create sequential waterfall reveals. **CRITICAL:** For `staggerChildren`, the Parent (`variants`) and Children MUST reside in the identical Client Component tree. If data is fetched asynchronously, pass the data as props into a centralized Parent Motion wrapper.
+* Apply grain/noise filters ONLY to fixed, pointer-events-none pseudo-elements
+* Animate exclusively via `transform` and `opacity` — never `top`, `left`, `width`, `height`
+* Use z-indexes strictly for systemic layers (nav, modals, overlays)
 
-## 5. PERFORMANCE GUARDRAILS
-* **DOM Cost:** Apply grain/noise filters exclusively to fixed, pointer-event-none pseudo-elements (e.g., `fixed inset-0 z-50 pointer-events-none`) and NEVER to scrolling containers to prevent continuous GPU repaints and mobile performance degradation.
-* **Hardware Acceleration:** Never animate `top`, `left`, `width`, or `height`. Animate exclusively via `transform` and `opacity`.
-* **Z-Index Restraint:** NEVER spam arbitrary `z-50` or `z-10` unprompted. Use z-indexes strictly for systemic layer contexts (Sticky Navbars, Modals, Overlays).
+## AI Tells (Forbidden Patterns)
 
-## 6. TECHNICAL REFERENCE (Dial Definitions)
+See [references/FORBIDDEN_PATTERNS.md](references/FORBIDDEN_PATTERNS.md) for the complete list of banned AI design signatures.
 
-### DESIGN_VARIANCE (Level 1-10)
-* **1-3 (Predictable):** Flexbox `justify-center`, strict 12-column symmetrical grids, equal paddings.
-* **4-7 (Offset):** Use `margin-top: -2rem` overlapping, varied image aspect ratios (e.g., 4:3 next to 16:9), left-aligned headers over center-aligned data.
-* **8-10 (Asymmetric):** Masonry layouts, CSS Grid with fractional units (e.g., `grid-template-columns: 2fr 1fr 1fr`), massive empty zones (`padding-left: 20vw`). 
-* **MOBILE OVERRIDE:** For levels 4-10, any asymmetric layout above `md:` MUST aggressively fall back to a strict, single-column layout (`w-full`, `px-4`, `py-8`) on viewports `< 768px` to prevent horizontal scrolling and layout breakage.
+Key bans: neon glows, pure black (#000), oversaturated accents, Inter font, 3-column card layouts, generic names/avatars/numbers, broken Unsplash links.
 
-### MOTION_INTENSITY (Level 1-10)
-* **1-3 (Static):** No automatic animations. CSS `:hover` and `:active` states only.
-* **4-7 (Fluid CSS):** Use `transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1)`. Use `animation-delay` cascades for load-ins. Focus strictly on `transform` and `opacity`. Use `will-change: transform` sparingly.
-* **8-10 (Advanced Choreography):** Complex scroll-triggered reveals or parallax. Use Framer Motion hooks. NEVER use `window.addEventListener('scroll')`.
+## Pre-Flight Check
 
-### VISUAL_DENSITY (Level 1-10)
-* **1-3 (Art Gallery Mode):** Lots of white space. Huge section gaps. Everything feels very expensive and clean.
-* **4-7 (Daily App Mode):** Normal spacing for standard web apps.
-* **8-10 (Cockpit Mode):** Tiny paddings. No card boxes; just 1px lines to separate data. Everything is packed. **Mandatory:** Use Monospace (`font-mono`) for all numbers.
+Before outputting, verify:
+- [ ] Mobile layout collapse guaranteed for high-variance designs
+- [ ] Full-height sections use `min-h-[100dvh]`
+- [ ] `useEffect` animations have cleanup functions
+- [ ] Empty, loading, and error states provided
+- [ ] CPU-heavy perpetual animations isolated in own Client Components
+- [ ] No banned patterns from AI Tells section
 
-## 7. AI TELLS (Forbidden Patterns)
-To guarantee a premium, non-generic output, you MUST strictly avoid these common AI design signatures unless explicitly requested:
+## References
 
-### Visual & CSS
-* **NO Neon/Outer Glows:** Do not use default `box-shadow` glows or auto-glows. Use inner borders or subtle tinted shadows.
-* **NO Pure Black:** Never use `#000000`. Use Off-Black, Zinc-950, or Charcoal.
-* **NO Oversaturated Accents:** Desaturate accents to blend elegantly with neutrals.
-* **NO Excessive Gradient Text:** Do not use text-fill gradients for large headers.
-* **NO Custom Mouse Cursors:** They are outdated and ruin performance/accessibility.
-
-### Typography
-* **NO Inter Font:** Banned. Use `Geist`, `Outfit`, `Cabinet Grotesk`, or `Satoshi`.
-* **NO Oversized H1s:** The first heading should not scream. Control hierarchy with weight and color, not just massive scale.
-* **Serif Constraints:** Use Serif fonts ONLY for creative/editorial designs. **NEVER** use Serif on clean Dashboards.
-
-### Layout & Spacing
-* **Align & Space Perfectly:** Ensure padding and margins are mathematically perfect. Avoid floating elements with awkward gaps.
-* **NO 3-Column Card Layouts:** The generic "3 equal cards horizontally" feature row is BANNED. Use a 2-column Zig-Zag, asymmetric grid, or horizontal scrolling approach instead.
-
-### Content & Data (The "Jane Doe" Effect)
-* **NO Generic Names:** "John Doe", "Sarah Chan", or "Jack Su" are banned. Use highly creative, realistic-sounding names.
-* **NO Generic Avatars:** DO NOT use standard SVG "egg" or Lucide user icons for avatars. Use creative, believable photo placeholders or specific styling.
-* **NO Fake Numbers:** Avoid predictable outputs like `99.99%`, `50%`, or basic phone numbers (`1234567`). Use organic, messy data (`47.2%`, `+1 (312) 847-1928`).
-* **NO Startup Slop Names:** "Acme", "Nexus", "SmartFlow". Invent premium, contextual brand names.
-* **NO Filler Words:** Avoid AI copywriting clichés like "Elevate", "Seamless", "Unleash", or "Next-Gen". Use concrete verbs.
-
-### External Resources & Components
-* **NO Broken Unsplash Links:** Do not use Unsplash. Use absolute, reliable placeholders like `https://picsum.photos/seed/{random_string}/800/600` or SVG UI Avatars.
-* **shadcn/ui Customization:** You may use `shadcn/ui`, but NEVER in its generic default state. You MUST customize the radii, colors, and shadows to match the high-end project aesthetic.
-* **Production-Ready Cleanliness:** Code must be extremely clean, visually striking, memorable, and meticulously refined in every detail.
-
-## 8. THE CREATIVE ARSENAL (High-End Inspiration)
-Do not default to generic UI. Pull from this library of advanced concepts to ensure the output is visually striking and memorable. When appropriate, leverage **GSAP (ScrollTrigger/Parallax)** for complex scrolltelling or **ThreeJS/WebGL** for 3D/Canvas animations, rather than basic CSS motion. **CRITICAL:** Never mix GSAP/ThreeJS with Framer Motion in the same component tree. Default to Framer Motion for UI/Bento interactions. Use GSAP/ThreeJS EXCLUSIVELY for isolated full-page scrolltelling or canvas backgrounds, wrapped in strict useEffect cleanup blocks.
-
-### The Standard Hero Paradigm
-* Stop doing centered text over a dark image. Try asymmetric Hero sections: Text cleanly aligned to the left or right. The background should feature a high-quality, relevant image with a subtle stylistic fade (darkening or lightening gracefully into the background color depending on if it is Light or Dark mode).
-
-### Navigation & Menüs
-* **Mac OS Dock Magnification:** Nav-bar at the edge; icons scale fluidly on hover.
-* **Magnetic Button:** Buttons that physically pull toward the cursor.
-* **Gooey Menu:** Sub-items detach from the main button like a viscous liquid.
-* **Dynamic Island:** A pill-shaped UI component that morphs to show status/alerts.
-* **Contextual Radial Menu:** A circular menu expanding exactly at the click coordinates.
-* **Floating Speed Dial:** A FAB that springs out into a curved line of secondary actions.
-* **Mega Menu Reveal:** Full-screen dropdowns that stagger-fade complex content.
-
-### Layout & Grids
-* **Bento Grid:** Asymmetric, tile-based grouping (e.g., Apple Control Center).
-* **Masonry Layout:** Staggered grid without fixed row heights (e.g., Pinterest).
-* **Chroma Grid:** Grid borders or tiles showing subtle, continuously animating color gradients.
-* **Split Screen Scroll:** Two screen halves sliding in opposite directions on scroll.
-* **Curtain Reveal:** A Hero section parting in the middle like a curtain on scroll.
-
-### Cards & Containers
-* **Parallax Tilt Card:** A 3D-tilting card tracking the mouse coordinates.
-* **Spotlight Border Card:** Card borders that illuminate dynamically under the cursor.
-* **Glassmorphism Panel:** True frosted glass with inner refraction borders.
-* **Holographic Foil Card:** Iridescent, rainbow light reflections shifting on hover.
-* **Tinder Swipe Stack:** A physical stack of cards the user can swipe away.
-* **Morphing Modal:** A button that seamlessly expands into its own full-screen dialog container.
-
-### Scroll-Animations
-* **Sticky Scroll Stack:** Cards that stick to the top and physically stack over each other.
-* **Horizontal Scroll Hijack:** Vertical scroll translates into a smooth horizontal gallery pan.
-* **Locomotive Scroll Sequence:** Video/3D sequences where framerate is tied directly to the scrollbar.
-* **Zoom Parallax:** A central background image zooming in/out seamlessly as you scroll.
-* **Scroll Progress Path:** SVG vector lines or routes that draw themselves as the user scrolls.
-* **Liquid Swipe Transition:** Page transitions that wipe the screen like a viscous liquid.
-
-### Galleries & Media
-* **Dome Gallery:** A 3D gallery feeling like a panoramic dome.
-* **Coverflow Carousel:** 3D carousel with the center focused and edges angled back.
-* **Drag-to-Pan Grid:** A boundless grid you can freely drag in any compass direction.
-* **Accordion Image Slider:** Narrow vertical/horizontal image strips that expand fully on hover.
-* **Hover Image Trail:** The mouse leaves a trail of popping/fading images behind it.
-* **Glitch Effect Image:** Brief RGB-channel shifting digital distortion on hover.
-
-### Typography & Text
-* **Kinetic Marquee:** Endless text bands that reverse direction or speed up on scroll.
-* **Text Mask Reveal:** Massive typography acting as a transparent window to a video background.
-* **Text Scramble Effect:** Matrix-style character decoding on load or hover.
-* **Circular Text Path:** Text curved along a spinning circular path.
-* **Gradient Stroke Animation:** Outlined text with a gradient continuously running along the stroke.
-* **Kinetic Typography Grid:** A grid of letters dodging or rotating away from the cursor.
-
-### Micro-Interactions & Effects
-* **Particle Explosion Button:** CTAs that shatter into particles upon success.
-* **Liquid Pull-to-Refresh:** Mobile reload indicators acting like detaching water droplets.
-* **Skeleton Shimmer:** Shifting light reflections moving across placeholder boxes.
-* **Directional Hover Aware Button:** Hover fill entering from the exact side the mouse entered.
-* **Ripple Click Effect:** Visual waves rippling precisely from the click coordinates.
-* **Animated SVG Line Drawing:** Vectors that draw their own contours in real-time.
-* **Mesh Gradient Background:** Organic, lava-lamp-like animated color blobs.
-* **Lens Blur Depth:** Dynamic focus blurring background UI layers to highlight a foreground action.
-
-## 9. THE "MOTION-ENGINE" BENTO PARADIGM
-When generating modern SaaS dashboards or feature sections, you MUST utilize the following "Bento 2.0" architecture and motion philosophy. This goes beyond static cards and enforces a "Vercel-core meets Dribbble-clean" aesthetic heavily reliant on perpetual physics.
-
-### A. Core Design Philosophy
-* **Aesthetic:** High-end, minimal, and functional.
-* **Palette:** Background in `#f9fafb`. Cards are pure white (`#ffffff`) with a 1px border of `border-slate-200/50`.
-* **Surfaces:** Use `rounded-[2.5rem]` for all major containers. Apply a "diffusion shadow" (a very light, wide-spreading shadow, e.g., `shadow-[0_20px_40px_-15px_rgba(0,0,0,0.05)]`) to create depth without clutter.
-* **Typography:** Strict `Geist`, `Satoshi`, or `Cabinet Grotesk` font stack. Use subtle tracking (`tracking-tight`) for headers.
-* **Labels:** Titles and descriptions must be placed **outside and below** the cards to maintain a clean, gallery-style presentation.
-* **Pixel-Perfection:** Use generous `p-8` or `p-10` padding inside cards.
-
-### B. The Animation Engine Specs (Perpetual Motion)
-All cards must contain **"Perpetual Micro-Interactions."** Use the following Framer Motion principles:
-* **Spring Physics:** No linear easing. Use `type: "spring", stiffness: 100, damping: 20` for a premium, weighty feel.
-* **Layout Transitions:** Heavily utilize the `layout` and `layoutId` props to ensure smooth re-ordering, resizing, and shared element state transitions.
-* **Infinite Loops:** Every card must have an "Active State" that loops infinitely (Pulse, Typewriter, Float, or Carousel) to ensure the dashboard feels "alive".
-* **Performance:** Wrap dynamic lists in `<AnimatePresence>` and optimize for 60fps. **PERFORMANCE CRITICAL:** Any perpetual motion or infinite loop MUST be memoized (React.memo) and completely isolated in its own microscopic Client Component. Never trigger re-renders in the parent layout.
-
-### C. The 5-Card Archetypes (Micro-Animation Specs)
-Implement these specific micro-animations when constructing Bento grids (e.g., Row 1: 3 cols | Row 2: 2 cols split 70/30):
-1. **The Intelligent List:** A vertical stack of items with an infinite auto-sorting loop. Items swap positions using `layoutId`, simulating an AI prioritizing tasks in real-time.
-2. **The Command Input:** A search/AI bar with a multi-step Typewriter Effect. It cycles through complex prompts, including a blinking cursor and a "processing" state with a shimmering loading gradient.
-3. **The Live Status:** A scheduling interface with "breathing" status indicators. Include a pop-up notification badge that emerges with an "Overshoot" spring effect, stays for 3 seconds, and vanishes.
-4. **The Wide Data Stream:** A horizontal "Infinite Carousel" of data cards or metrics. Ensure the loop is seamless (using `x: ["0%", "-100%"]`) with a speed that feels effortless.
-5. **The Contextual UI (Focus Mode):** A document view that animates a staggered highlight of a text block, followed by a "Float-in" of a floating action toolbar with micro-icons.
-
-## 10. FINAL PRE-FLIGHT CHECK
-Evaluate your code against this matrix before outputting. This is the **last** filter you apply to your logic.
-- [ ] Is global state used appropriately to avoid deep prop-drilling rather than arbitrarily?
-- [ ] Is mobile layout collapse (`w-full`, `px-4`, `max-w-7xl mx-auto`) guaranteed for high-variance designs?
-- [ ] Do full-height sections safely use `min-h-[100dvh]` instead of the bugged `h-screen`?
-- [ ] Do `useEffect` animations contain strict cleanup functions?
-- [ ] Are empty, loading, and error states provided?
-- [ ] Are cards omitted in favor of spacing where possible?
-- [ ] Did you strictly isolate CPU-heavy perpetual animations in their own Client Components?
+- [references/DIAL_DEFINITIONS.md](references/DIAL_DEFINITIONS.md) — Detailed dial level specifications
+- [references/CREATIVE_ARSENAL.md](references/CREATIVE_ARSENAL.md) — High-end UI patterns and motion engine specs
+- [references/DESIGN_RULES.md](references/DESIGN_RULES.md) — Anti-slop implementation details
+- [references/FORBIDDEN_PATTERNS.md](references/FORBIDDEN_PATTERNS.md) — Banned AI design signatures

--- a/frontend/taste-skill/references/CREATIVE_ARSENAL.md
+++ b/frontend/taste-skill/references/CREATIVE_ARSENAL.md
@@ -1,0 +1,67 @@
+# Creative Arsenal — High-End UI Inspiration
+
+Do not default to generic UI. Pull from this library of advanced concepts. When appropriate, leverage **GSAP (ScrollTrigger/Parallax)** for scrolltelling or **ThreeJS/WebGL** for 3D/Canvas animations.
+
+**CRITICAL:** Never mix GSAP/ThreeJS with Framer Motion in the same component tree. Default to Framer Motion for UI interactions. Use GSAP/ThreeJS EXCLUSIVELY for isolated full-page scrolltelling or canvas backgrounds, wrapped in strict useEffect cleanup blocks.
+
+## Hero Sections
+* Asymmetric layouts: text left/right-aligned with stylistic fade backgrounds
+* Stop doing centered text over dark images
+
+## Navigation
+* **Mac OS Dock Magnification:** Nav-bar with icons scaling on hover
+* **Magnetic Button:** Buttons that physically pull toward cursor
+* **Gooey Menu:** Sub-items detach from main button like viscous liquid
+* **Dynamic Island:** Pill-shaped component that morphs for status/alerts
+* **Contextual Radial Menu:** Circular menu at click coordinates
+* **Floating Speed Dial:** FAB springing out into curved secondary actions
+* **Mega Menu Reveal:** Full-screen dropdowns with stagger-fade content
+
+## Layout & Grids
+* **Bento Grid:** Asymmetric, tile-based grouping (Apple Control Center style)
+* **Masonry Layout:** Staggered grid without fixed row heights
+* **Chroma Grid:** Borders/tiles with continuously animating color gradients
+* **Split Screen Scroll:** Two halves sliding in opposite directions
+* **Curtain Reveal:** Hero section parting in the middle on scroll
+
+## Cards & Containers
+* **Parallax Tilt Card:** 3D-tilting card tracking mouse coordinates
+* **Spotlight Border Card:** Borders illuminate dynamically under cursor
+* **Glassmorphism Panel:** True frosted glass with inner refraction borders
+* **Holographic Foil Card:** Iridescent rainbow reflections on hover
+* **Tinder Swipe Stack:** Physical card stack with swipe gestures
+* **Morphing Modal:** Button expanding seamlessly into dialog container
+
+## Scroll Animations
+* **Sticky Scroll Stack:** Cards sticking and stacking at top
+* **Horizontal Scroll Hijack:** Vertical scroll → horizontal gallery pan
+* **Locomotive Scroll Sequence:** Video framerate tied to scrollbar
+* **Zoom Parallax:** Background zooming in/out on scroll
+* **Scroll Progress Path:** SVG lines drawing on scroll
+* **Liquid Swipe Transition:** Viscous liquid page wipe
+
+## Galleries & Media
+* **Dome Gallery:** 3D panoramic dome feeling
+* **Coverflow Carousel:** 3D carousel with center focus
+* **Drag-to-Pan Grid:** Boundless draggable grid
+* **Accordion Image Slider:** Strips expanding fully on hover
+* **Hover Image Trail:** Popping/fading image trail behind mouse
+* **Glitch Effect Image:** RGB-channel shifting distortion on hover
+
+## Typography & Text
+* **Kinetic Marquee:** Text bands reversing direction on scroll
+* **Text Mask Reveal:** Typography as transparent window to video
+* **Text Scramble Effect:** Matrix-style character decoding
+* **Circular Text Path:** Text on spinning circular path
+* **Gradient Stroke Animation:** Outlined text with running gradient
+* **Kinetic Typography Grid:** Letters dodging/rotating from cursor
+
+## Micro-Interactions & Effects
+* **Particle Explosion Button:** CTAs shattering into particles on success
+* **Liquid Pull-to-Refresh:** Water droplet reload indicators
+* **Skeleton Shimmer:** Shifting light on placeholder boxes
+* **Directional Hover Button:** Fill entering from mouse entry side
+* **Ripple Click Effect:** Waves from click coordinates
+* **Animated SVG Line Drawing:** Vectors drawing contours in real-time
+* **Mesh Gradient Background:** Organic animated color blobs
+* **Lens Blur Depth:** Dynamic background blur for foreground focus

--- a/frontend/taste-skill/references/DESIGN_RULES.md
+++ b/frontend/taste-skill/references/DESIGN_RULES.md
@@ -1,0 +1,45 @@
+# Anti-Slop Implementation (Creative Proactivity)
+
+## Liquid Glass Refraction
+
+When glassmorphism is needed, go beyond `backdrop-blur`. Add a 1px inner border (`border-white/10`) and a subtle inner shadow (`shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]`) to simulate physical edge refraction.
+
+## Magnetic Micro-physics (MOTION_INTENSITY > 5)
+
+Implement buttons that pull slightly toward the mouse cursor. **CRITICAL:** NEVER use React `useState` for magnetic hover or continuous animations. Use EXCLUSIVELY Framer Motion's `useMotionValue` and `useTransform` outside the React render cycle to prevent performance collapse on mobile.
+
+## Perpetual Micro-Interactions (MOTION_INTENSITY > 5)
+
+Embed continuous, infinite micro-animations (Pulse, Typewriter, Float, Shimmer, Carousel) in standard components. Apply premium Spring Physics (`type: "spring", stiffness: 100, damping: 20`) to all interactive elements — no linear easing.
+
+## Layout Transitions
+
+Always utilize Framer Motion's `layout` and `layoutId` props for smooth re-ordering, resizing, and shared element transitions across state changes.
+
+## Staggered Orchestration
+
+Do not mount lists or grids instantly. Use `staggerChildren` (Framer) or CSS cascade (`animation-delay: calc(var(--index) * 100ms)`) to create sequential waterfall reveals.
+
+**CRITICAL:** For `staggerChildren`, the Parent (`variants`) and Children MUST reside in the identical Client Component tree. If data is fetched asynchronously, pass the data as props into a centralized Parent Motion wrapper.
+
+## The "Motion-Engine" Bento Paradigm
+
+For modern SaaS dashboards or feature sections, use this "Bento 2.0" architecture:
+
+### Core Design Philosophy
+* Background: `#f9fafb`. Cards: pure white with 1px `border-slate-200/50`.
+* Use `rounded-[2.5rem]` for major containers. Diffusion shadow: `shadow-[0_20px_40px_-15px_rgba(0,0,0,0.05)]`.
+* Typography: `Geist`, `Satoshi`, or `Cabinet Grotesk`. Labels outside and below cards.
+
+### Animation Engine (Perpetual Motion)
+* Spring Physics: `type: "spring", stiffness: 100, damping: 20`
+* Layout Transitions: Heavily use `layout` and `layoutId` props
+* Infinite Loops: Every card must have an "Active State" that loops (Pulse, Typewriter, Float, Carousel)
+* **PERFORMANCE CRITICAL:** Perpetual motion MUST be memoized (React.memo) and isolated in its own Client Component
+
+### 5-Card Archetypes
+1. **The Intelligent List:** Auto-sorting loop using `layoutId`
+2. **The Command Input:** Multi-step Typewriter Effect with blinking cursor and shimmer loading
+3. **The Live Status:** Breathing indicators with "Overshoot" spring notification badges
+4. **The Wide Data Stream:** Infinite horizontal carousel (`x: ["0%", "-100%"]`)
+5. **The Contextual UI:** Staggered highlight + float-in toolbar

--- a/frontend/taste-skill/references/DIAL_DEFINITIONS.md
+++ b/frontend/taste-skill/references/DIAL_DEFINITIONS.md
@@ -1,0 +1,20 @@
+# Dial Definitions
+
+## DESIGN_VARIANCE (Level 1-10)
+
+* **1-3 (Predictable):** Flexbox `justify-center`, strict 12-column symmetrical grids, equal paddings.
+* **4-7 (Offset):** Use `margin-top: -2rem` overlapping, varied image aspect ratios (e.g., 4:3 next to 16:9), left-aligned headers over center-aligned data.
+* **8-10 (Asymmetric):** Masonry layouts, CSS Grid with fractional units (e.g., `grid-template-columns: 2fr 1fr 1fr`), massive empty zones (`padding-left: 20vw`).
+* **MOBILE OVERRIDE:** For levels 4-10, any asymmetric layout above `md:` MUST fall back to single-column (`w-full`, `px-4`, `py-8`) on viewports `< 768px`.
+
+## MOTION_INTENSITY (Level 1-10)
+
+* **1-3 (Static):** No automatic animations. CSS `:hover` and `:active` states only.
+* **4-7 (Fluid CSS):** Use `transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1)`. Use `animation-delay` cascades for load-ins. Focus on `transform` and `opacity`. Use `will-change: transform` sparingly.
+* **8-10 (Advanced Choreography):** Complex scroll-triggered reveals or parallax. Use Framer Motion hooks. NEVER use `window.addEventListener('scroll')`.
+
+## VISUAL_DENSITY (Level 1-10)
+
+* **1-3 (Art Gallery Mode):** Lots of white space. Huge section gaps. Expensive and clean feel.
+* **4-7 (Daily App Mode):** Normal spacing for standard web apps.
+* **8-10 (Cockpit Mode):** Tiny paddings. No card boxes; just 1px lines to separate data. Everything packed. **Mandatory:** Use Monospace (`font-mono`) for all numbers.

--- a/frontend/taste-skill/references/FORBIDDEN_PATTERNS.md
+++ b/frontend/taste-skill/references/FORBIDDEN_PATTERNS.md
@@ -1,0 +1,31 @@
+# Forbidden Patterns — AI Tells
+
+Banned AI design signatures. Strictly avoid these unless explicitly requested.
+
+## Visual & CSS
+* **NO Neon/Outer Glows:** No default `box-shadow` glows. Use inner borders or subtle tinted shadows.
+* **NO Pure Black:** Never use `#000000`. Use Off-Black, Zinc-950, or Charcoal.
+* **NO Oversaturated Accents:** Desaturate accents to blend with neutrals.
+* **NO Excessive Gradient Text:** No text-fill gradients for large headers.
+* **NO Custom Mouse Cursors:** Outdated and ruins performance/accessibility.
+
+## Typography
+* **NO Inter Font:** Banned. Use `Geist`, `Outfit`, `Cabinet Grotesk`, or `Satoshi`.
+* **NO Oversized H1s:** Control hierarchy with weight and color, not massive scale.
+* **Serif Constraints:** Serif ONLY for creative/editorial. NEVER on dashboards.
+
+## Layout & Spacing
+* **Align & Space Perfectly:** Ensure padding/margins are mathematically precise.
+* **NO 3-Column Card Layouts:** The generic "3 equal cards" feature row is banned. Use 2-column zig-zag, asymmetric grid, or horizontal scrolling.
+
+## Content & Data (The "Jane Doe" Effect)
+* **NO Generic Names:** "John Doe", "Sarah Chan" are banned. Use creative, realistic names.
+* **NO Generic Avatars:** No SVG "egg" or Lucide user icons. Use photo placeholders or styled alternatives.
+* **NO Fake Numbers:** No `99.99%`, `50%`. Use organic data (`47.2%`, `+1 (312) 847-1928`).
+* **NO Startup Slop Names:** "Acme", "Nexus", "SmartFlow" are banned. Invent premium names.
+* **NO Filler Words:** Ban "Elevate", "Seamless", "Unleash", "Next-Gen". Use concrete verbs.
+
+## External Resources & Components
+* **NO Broken Unsplash Links:** Use `https://picsum.photos/seed/{random_string}/800/600` or SVG UI Avatars.
+* **shadcn/ui Customization:** Never use in default state. Customize radii, colors, shadows.
+* **Production-Ready:** Code must be clean, visually striking, and meticulously refined.

--- a/pentest/web-spider/SKILL.md
+++ b/pentest/web-spider/SKILL.md
@@ -1,244 +1,88 @@
 ---
-name: Web Application Spider & Crawler
-description: >
-  Intelligent web crawler for discovering endpoints, forms, links, and API routes. Extracts JavaScript endpoints and supports depth-limited crawling with categorized output.
+name: web-spider
+description: "Crawl web applications to discover endpoints, forms, links, and API routes. Use for attack surface mapping, breadth-first site crawling with depth limits, JavaScript endpoint extraction, form discovery, and generating structured JSON output for downstream pentest tools."
+allowed-tools: Bash(curl:*) Read Write
+metadata:
+  author: roundtable
+  version: "1.0"
+  tier: pentest
+  compatibility: Requires curl; no jq dependency
 ---
 
 # Web Application Spider & Crawler
 
 Intelligent web crawler for discovering attack surface, endpoints, forms, and API routes.
 
-## Features
+## When to Use
 
-- **Smart Crawling**: Breadth-first traversal with depth limiting
-- **Link Extraction**: HTML `<a>`, `<form>`, `<script>`, `<link>` tags
-- **JavaScript Analysis**: Static extraction of API endpoints from JS files
-- **Form Discovery**: Extracts forms with fields, methods, and actions
-- **Scope Control**: Same-domain, same-host, or unrestricted crawling
-- **Categorization**: Pages, APIs, forms, assets (CSS, JS, images)
-- **Deduplication**: URL normalization to avoid redundant crawling
-- **JSON Output**: Structured output for downstream tools
+- Map attack surface before vulnerability scanning
+- Discover hidden endpoints and API routes
+- Extract forms for parameter testing
+- Feed discovered URLs to other pentest skills (vuln-scan, post-parameter-tester)
 
-## Architecture
+## Workflow
 
-```
-web-spider/
-├── SKILL.md                # This file - AgentSkills.io spec
-├── README.md              # User documentation
-├── scripts/
-│   ├── spider.sh          # Main crawler with link extraction
-│   ├── js-endpoints.sh    # JavaScript endpoint extractor
-│   ├── extract-forms.sh   # HTML form parser
-│   └── url-normalize.sh   # URL deduplication helper
-├── references/
-│   ├── URL_PATTERNS.md    # Common endpoint patterns
-│   └── FORM_EXTRACTION.md # Form parsing guide
-└── tests/
-    └── test-suite.sh      # Integration tests
-```
+1. Run `spider.sh` against target URL with appropriate scope and depth
+2. Review discovered endpoints, forms, and API routes in JSON output
+3. Extract JavaScript endpoints with `js-endpoints.sh` for additional coverage
+4. Parse forms with `extract-forms.sh` for parameter testing
+5. Feed results to downstream tools (nuclei, post-parameter-tester)
 
 ## Quick Start
 
 ```bash
-# Basic crawl
+# Basic crawl (default: depth 3, 100 pages, same-domain scope)
 ./scripts/spider.sh https://example.com
 
 # Deep crawl with JS analysis
-./scripts/spider.sh https://example.com \
-  --max-depth 5 \
-  --extract-js
+./scripts/spider.sh https://example.com --max-depth 5 --extract-js
 
 # Authenticated crawl
-./scripts/spider.sh https://app.example.com \
-  --cookie "PHPSESSID=abc123" \
-  --max-pages 200
+./scripts/spider.sh https://app.example.com --cookie "PHPSESSID=abc123" --max-pages 200
 ```
 
-## Output Format
+## Scripts
 
-```json
-{
-  "target": "https://example.com",
-  "start_time": "2026-03-16T09:00:00Z",
-  "end_time": "2026-03-16T09:02:15Z",
-  "crawl_config": {
-    "max_depth": 3,
-    "max_pages": 100,
-    "scope": "same-domain"
-  },
-  "discovered": {
-    "pages": [
-      {
-        "url": "https://example.com/about",
-        "depth": 1,
-        "status_code": 200,
-        "title": "About Us"
-      }
-    ],
-    "api_endpoints": [
-      {
-        "url": "https://api.example.com/users",
-        "method": "GET",
-        "source": "app.js",
-        "type": "rest"
-      }
-    ],
-    "forms": [
-      {
-        "url": "https://example.com/login",
-        "action": "/auth/login",
-        "method": "POST",
-        "fields": [
-          {"name": "username", "type": "text"},
-          {"name": "password", "type": "password"}
-        ]
-      }
-    ],
-    "static_assets": [
-      {
-        "url": "https://example.com/css/style.css",
-        "type": "stylesheet"
-      }
-    ]
-  },
-  "summary": {
-    "total_urls": 150,
-    "pages_crawled": 45,
-    "forms_found": 3,
-    "api_endpoints_found": 12,
-    "static_assets": 90,
-    "duration_seconds": 135
-  }
-}
-```
-
-## Usage Examples
-
-### 1. Discover All Endpoints
-
-```bash
-./scripts/spider.sh https://example.com \
-  --max-depth 4 \
-  --max-pages 200 \
-  --output endpoints.json
-```
-
-### 2. Extract API Endpoints from JavaScript
-
-```bash
-# Single file
-./scripts/js-endpoints.sh https://app.example.com/static/app.js
-
-# All JS files from a crawl
-cat crawl-results.json | \
-  jq -r '.discovered.static_assets[] | select(.type=="javascript") | .url' | \
-  while read js_url; do
-    ./scripts/js-endpoints.sh "$js_url"
-  done
-```
-
-### 3. Find All Forms
-
-```bash
-./scripts/spider.sh https://example.com | \
-  jq '.discovered.forms[]'
-```
-
-### 4. Integration with POST Parameter Tester
-
-```bash
-# Crawl and test all POST forms
-./scripts/spider.sh https://example.com --output spider.json
-
-cat spider.json | jq -r '.discovered.forms[] | 
-  select(.method=="POST") | 
-  "\(.url) \(.fields | map(.name + "=test") | join("&"))"' | \
-  while read url params; do
-    /skills/pentest/post-parameter-tester/scripts/test-post.sh "$url" "$params"
-  done
-```
+| Script | Purpose |
+|--------|---------|
+| `scripts/spider.sh` | Main crawler with link extraction |
+| `scripts/js-endpoints.sh` | JavaScript endpoint extractor (fetch, axios, XHR, jQuery, GraphQL) |
+| `scripts/extract-forms.sh` | HTML form parser |
+| `scripts/url-normalize.sh` | URL deduplication helper |
 
 ## Scope Modes
 
-- **same-domain**: Crawl all subdomains
-  - `https://example.com` → includes `api.example.com`, `www.example.com`
-  
+- **same-domain**: All subdomains (e.g., includes `api.example.com`)
 - **same-host**: Exact hostname only
-  - `https://app.example.com` → excludes `api.example.com`
-  
-- **all**: Follow all links (use with caution!)
-  - May crawl external sites, CDNs, social media
+- **all**: Follow all links (use with caution)
 
-## JavaScript Endpoint Extraction
-
-The `js-endpoints.sh` script detects:
-
-- **fetch() API**: `fetch('/api/users')`
-- **axios**: `axios.get('/api/data')`
-- **XMLHttpRequest**: `xhr.open('GET', '/api/endpoint')`
-- **jQuery AJAX**: `$.ajax({url: '/api/resource'})`
-- **REST patterns**: `/api/v1/users`, `/v2/products/{id}`
-- **GraphQL**: `/graphql`, `query { users { ... } }`
-
-## Performance Considerations
-
-- **Rate Limiting**: 1 second delay between requests (default)
-- **Max Pages**: Default 100 pages to avoid excessive crawling
-- **Timeout**: 10 second timeout per request
-- **Memory**: Stores all URLs in memory - limit with --max-pages
-
-## Limitations
-
-- **No JS Rendering**: Static HTML only (can't execute JavaScript)
-  - Use Puppeteer/Playwright for SPAs
-- **No Authentication**: Cookie-based auth only (no OAuth flows)
-- **No Form Submission**: Discovery only, not interaction
-- **Static Analysis**: May miss dynamic/runtime-generated endpoints
-
-## Roadmap
-
-- [ ] Headless browser support (Puppeteer) for JS rendering
-- [ ] GraphQL schema introspection
-- [ ] OpenAPI/Swagger endpoint import
-- [ ] Screenshot capture of discovered pages
-- [ ] Broken link detection
-- [ ] Sitemap.xml parsing
-- [ ] robots.txt analysis
-- [ ] Concurrent/parallel crawling
-- [ ] Resume capability for large crawls
-- [ ] Authentication flow support (OAuth, SAML)
-
-## Integration Examples
-
-### With Directory Enumeration
+## Integration with Other Skills
 
 ```bash
-# Crawl discovered pages, then enumerate directories
+# Crawl and feed POST forms to parameter tester
 ./scripts/spider.sh https://example.com --output spider.json
 
-cat spider.json | jq -r '.discovered.pages[].url' | \
-  sed 's|/[^/]*$||' | sort -u | \
-  while read dir; do
-    gobuster dir -u "$dir" -w /usr/share/wordlists/dirb/common.txt
-  done
-```
+# Extract form URLs for post-parameter-tester
+grep -o '"action":"[^"]*"' spider.json | cut -d'"' -f4
 
-### With Vulnerability Scanner
-
-```bash
-# Discover endpoints, then scan with nuclei
-./scripts/spider.sh https://example.com | \
-  jq -r '.discovered.pages[].url' > urls.txt
-
+# Feed discovered URLs to nuclei
+./scripts/spider.sh https://example.com | grep -o '"url":"[^"]*"' | cut -d'"' -f4 > urls.txt
 nuclei -l urls.txt -t ~/nuclei-templates/
 ```
 
-## Contributing
+## Performance
 
-Improvements welcome! Add endpoint patterns to `references/URL_PATTERNS.md`.
+- **Rate Limiting**: 1 second delay between requests (default)
+- **Max Pages**: Default 100 pages
+- **Timeout**: 10 seconds per request
 
----
+## Limitations
 
-**Author**: Sir Agravain, Knight of Pentesting  
-**Created**: 2026-03-16  
-**Version**: 1.0.0
+- Static HTML only — no JS rendering (use Puppeteer for SPAs)
+- Cookie-based auth only (no OAuth flows)
+- Discovery only, not form submission
+- May miss dynamic/runtime-generated endpoints
+
+See [references/URL_PATTERNS.md](references/URL_PATTERNS.md) for common endpoint patterns and [references/FORM_EXTRACTION.md](references/FORM_EXTRACTION.md) for form parsing details.
+
+See [references/OUTPUT_FORMAT.md](references/OUTPUT_FORMAT.md) for the full JSON output schema and integration examples.

--- a/pentest/web-spider/references/OUTPUT_FORMAT.md
+++ b/pentest/web-spider/references/OUTPUT_FORMAT.md
@@ -1,0 +1,107 @@
+# Web Spider Output Format
+
+## JSON Output Schema
+
+```json
+{
+  "target": "https://example.com",
+  "start_time": "2026-03-16T09:00:00Z",
+  "end_time": "2026-03-16T09:02:15Z",
+  "crawl_config": {
+    "max_depth": 3,
+    "max_pages": 100,
+    "scope": "same-domain"
+  },
+  "discovered": {
+    "pages": [
+      {
+        "url": "https://example.com/about",
+        "depth": 1,
+        "status_code": 200,
+        "title": "About Us"
+      }
+    ],
+    "api_endpoints": [
+      {
+        "url": "https://api.example.com/users",
+        "method": "GET",
+        "source": "app.js",
+        "type": "rest"
+      }
+    ],
+    "forms": [
+      {
+        "url": "https://example.com/login",
+        "action": "/auth/login",
+        "method": "POST",
+        "fields": [
+          {"name": "username", "type": "text"},
+          {"name": "password", "type": "password"}
+        ]
+      }
+    ],
+    "static_assets": [
+      {
+        "url": "https://example.com/css/style.css",
+        "type": "stylesheet"
+      }
+    ]
+  },
+  "summary": {
+    "total_urls": 150,
+    "pages_crawled": 45,
+    "forms_found": 3,
+    "api_endpoints_found": 12,
+    "static_assets": 90,
+    "duration_seconds": 135
+  }
+}
+```
+
+## JavaScript Endpoint Detection
+
+The `js-endpoints.sh` script detects:
+
+- **fetch() API**: `fetch('/api/users')`
+- **axios**: `axios.get('/api/data')`
+- **XMLHttpRequest**: `xhr.open('GET', '/api/endpoint')`
+- **jQuery AJAX**: `$.ajax({url: '/api/resource'})`
+- **REST patterns**: `/api/v1/users`, `/v2/products/{id}`
+- **GraphQL**: `/graphql`, `query { users { ... } }`
+
+## Integration Examples
+
+### With Directory Enumeration
+
+```bash
+# Crawl discovered pages, then enumerate directories
+./scripts/spider.sh https://example.com --output spider.json
+
+grep -o '"url":"[^"]*"' spider.json | cut -d'"' -f4 | \
+  sed 's|/[^/]*$||' | sort -u | \
+  while read dir; do
+    gobuster dir -u "$dir" -w /usr/share/wordlists/dirb/common.txt
+  done
+```
+
+### With Vulnerability Scanner
+
+```bash
+# Discover endpoints, then scan with nuclei
+./scripts/spider.sh https://example.com | \
+  grep -o '"url":"[^"]*"' | cut -d'"' -f4 > urls.txt
+
+nuclei -l urls.txt -t ~/nuclei-templates/
+```
+
+### With POST Parameter Tester
+
+```bash
+# Crawl and test all POST forms
+./scripts/spider.sh https://example.com --output spider.json
+
+grep -o '"method":"POST"' -A5 spider.json | grep -o '"action":"[^"]*"' | cut -d'"' -f4 | \
+  while read url; do
+    /skills/pentest/post-parameter-tester/scripts/test-post.sh "$url"
+  done
+```

--- a/wellness/family-health/SKILL.md
+++ b/wellness/family-health/SKILL.md
@@ -1,17 +1,38 @@
-# Family Health & Wellness Skill
+---
+name: family-health
+description: "Track pregnancy milestones, meal planning, nutrition, and family wellbeing. Use for weekly wellness reports, trimester-appropriate meal plans, activity suggestions, and prenatal health monitoring."
+allowed-tools: Read Write
+metadata:
+  author: roundtable
+  version: "1.0"
+  tier: wellness
+---
+
+# Family Health & Wellness
 
 Track pregnancy milestones, meal planning, nutrition, and family wellbeing.
 
 ## Context Files
+
 Read these for current family status:
 - `/vault/Personal/Family/Emma.md` — baby timeline, milestones, prep status
 - `/vault/Personal/Family/Sara.md` — Sara's info and preferences
 - `/vault/Briefings/Home/` — recent household briefings
 
 ## Pregnancy Tracking
+
 Emma's due date: April 29, 2026. Calculate current week from that.
 
-### Weekly Report Template
+## Workflow
+
+1. Read context files for current family status
+2. Calculate current pregnancy week from due date
+3. Generate report sections: pregnancy update, meal ideas, activity suggestions, action items
+4. Write full report to `/vault/Briefings/Home/wellness-report-YYYY-MM-DD.md`
+5. Return concise NATS summary (5-10 bullet points)
+
+## Weekly Report Template
+
 ```markdown
 # Wellness Report — YYYY-MM-DD
 
@@ -35,6 +56,7 @@ Emma's due date: April 29, 2026. Calculate current week from that.
 ```
 
 ## Meal Planning
+
 When asked for meal plans:
 - Consider trimester-appropriate nutrition
 - Sara is Spanish — include Mediterranean-friendly options
@@ -42,6 +64,7 @@ When asked for meal plans:
 - Write plans to `/vault/Briefings/Home/meal-plan-YYYY-MM-DD.md`
 
 ## Output Contract
+
 - Write full reports to `/vault/Briefings/Home/`
 - Return concise NATS summary (5-10 bullet points)
 - Always calculate current pregnancy week from due date


### PR DESCRIPTION
Hey @dapperdivers 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="910" alt="image" src="https://github.com/user-attachments/assets/8940fd19-d1b0-42b5-bd49-056f10e05d10" />


Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| wellness/family-health | 10% | 80% | +70% |
| pentest/web-spider | 18% | 89% | +71% |
| frontend/taste-skill | 34% | 85% | +51% |
| career/daily-career-report | 47% | 77% | +30% |
| finance/daily-finance-report | 49% | 83% | +34% |

This PR is intentionally scoped to the 5 lowest-scoring skills to keep it reviewable. More skills can be improved in follow-ups or via automated review on future PRs.

<details>
<summary>Changes summary</summary>

**wellness/family-health (10% → 80%)**
- Added missing YAML frontmatter (name, description, allowed-tools, metadata) — the skill had no frontmatter at all, causing near-zero score
- Added explicit workflow section with step-by-step execution order

**pentest/web-spider (18% → 89%)**
- Fixed `name` field from "Web Application Spider & Crawler" to "web-spider" to match directory (kebab-case requirement)
- Replaced `jq` usage in examples with `grep`/`cut`/`sed` per CONTRIBUTING.md (no jq in containers)
- Moved JSON output schema and integration examples to `references/OUTPUT_FORMAT.md` for progressive disclosure
- Added structured workflow section and "When to Use" triggers
- Removed roadmap/contributing sections (not agent-actionable)

**frontend/taste-skill (34% → 85%)**
- Fixed `name` from "design-taste-frontend" to "taste-skill" to match directory name
- Expanded description with clear activation triggers
- Split 227-line monolith into SKILL.md + 4 reference files for progressive disclosure
- Added workflow section with step-by-step execution order

**career/daily-career-report (47% → 77%)**
- Fixed description from chevron `>` format to proper quoted string
- Expanded description with specific activation triggers
- Moved JSON example and format templates to `references/REPORT_FORMAT.md`
- Added explicit workflow section and "When to Use" triggers

**finance/daily-finance-report (49% → 83%)**
- Expanded thin description with specific capabilities and activation triggers
- Moved config file schemas to `references/CONFIG_SCHEMAS.md`
- Added explicit workflow section and "When to Use" triggers

</details>

All changes follow the repo's CONTRIBUTING.md conventions: SKILL.md files stay under 500 lines, heavy content moved to `references/`, names match directories in kebab-case, no jq usage, and metadata fields included.

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@rohan-tessl](https://github.com/rohan-tessl) - if you hit any snags.

Thanks in advance 🙏
