### PR TITLE
feat: night-watch skills (telemetry queries, triage, fix procedure)

### DIFF
--- a/coding/night-watch-fix/SKILL.md
+++ b/coding/night-watch-fix/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: night-watch-fix
+description: Execute a Night Watch fix Mission - reproduce, fix, test, and open a PR for an incident dispatched by the watchman. Use when a mission briefing references a Night-Watch fingerprint.
+---
+
+# Night Watch Fix Procedure
+
+You received a Mission briefing with a fingerprint, evidence, and a target repo.
+The deliverable is a **PR**, or an explicit, well-argued "not a bug" verdict.
+Follow coding-agent rules (branch, tests, PR); this skill adds the Night Watch
+specifics.
+
+## Per-repo procedure
+
+| Repo | Verify before push |
+|---|---|
+| dapperdivers/pi-knight | `npm ci && npx tsc --noEmit && npm test && npm run build` |
+| dapperdivers/roundtable-ui | `cd api && go build ./... && go vet ./... && go test ./...`; UI changes: `cd ui && npm install && npm run build` |
+| dapperdivers/roundtable | `go build ./... && go vet ./...`; run `make test` (envtest) — if the sandbox can't, say so in the PR body |
+| dapperdivers/roundtable-arsenal | skills are markdown: valid YAML frontmatter (`name`, `description`), check referenced paths/commands actually exist |
+| dapperdivers/nats-bridge | check package.json/Makefile for the test command; at minimum build clean |
+| dapperdivers/dapper-cluster | **`kubernetes/apps/roundtable/**` paths ONLY** — never touch anything else. Update the matching `kustomization.yaml` for new files. |
+
+## Rules
+
+1. **Reproduce first when feasible.** A failing test that demonstrates the bug is
+   worth more than the fix itself — it becomes the regression guard. If you
+   cannot reproduce, say so in the PR body and explain your confidence anyway.
+2. **Branch**: `night-watch/<fingerprint>`. Commits: conventional
+   (`fix: <what> (night-watch <fp>)`). Never push to main. No Co-Authored-By lines.
+3. **Smallest correct fix.** No drive-by refactors; the human reviewing at 7 AM
+   must be able to grasp the diff in one read.
+4. **PR body template** (the trailer line is machine-read — keep it exact):
+
+   ```
+   ## Night Watch fix
+
+   **Incident:** <one-line summary>
+   **Evidence:** <key log lines / metrics from the briefing>
+   **Root cause:** <what was actually wrong>
+   **Fix:** <what you changed and why this addresses the root cause>
+   **Reproduced:** yes — <how> | no — <why not>
+   **Tests:** <suites run + results>
+
+   Night-Watch-Fingerprint: <fp>
+   ```
+
+## AUTOMERGE POLICY — current phase: 2 (human merges)
+
+Do NOT run `gh pr merge` in any form. Open the PR and stop.
+(Tier rules will be enabled here in Phase 3 — tier 1: arsenal + roundtable
+manifests may auto-merge on green; tier 3: operator Go code, workflows, RBAC,
+renovate config NEVER auto-merge.)
+
+## Protected paths — never modify, any repo, any tier
+
+- `.github/workflows/**`
+- `kubernetes/apps/roundtable/infrastructure/app/*rbac*.yaml`, `*secret*.yaml`
+- `.renovate/**`, `renovate.json*`
+
+If the fix genuinely requires one of these, stop and say so in your result —
+that escalation is a human decision.
+
+## Afterwards
+
+End your result with: PR URL, fingerprint, repos touched, test results.
+The watchman reads Mission results to update the ledger — make them parseable
+at a glance.

--- a/coding/night-watch-fix/SKILL.md
+++ b/coding/night-watch-fix/SKILL.md
@@ -10,6 +10,9 @@ The deliverable is a **PR**, or an explicit, well-argued "not a bug" verdict.
 Follow coding-agent rules (branch, tests, PR); this skill adds the Night Watch
 specifics.
 
+Read your repo's codebase skill first: `coding/roundtable-operator`,
+`coding/pi-knight-runtime`, `coding/roundtable-ui`, or `coding/roundtable-arsenal`.
+
 ## Per-repo procedure
 
 | Repo | Verify before push |

--- a/watch/night-watch-triage/SKILL.md
+++ b/watch/night-watch-triage/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: night-watch-triage
+description: Turn collected telemetry into fingerprinted incidents, dedup against the ledger and prior Missions, and dispatch at most three fix Missions per night. Use during the Night Watch triage step.
+---
+
+# Night Watch Triage
+
+You turn raw error signatures into **incidents**, keep the ledger truthful, and
+dispatch fix Missions. You never fix anything yourself.
+
+## Fingerprinting
+
+A fingerprint identifies a *bug*, not an *occurrence*:
+
+```
+fp = first 12 hex of sha256("<workload>|<normalized-signature>")
+```
+
+- `workload`: the owning deployment/knight name (`coder-1`, `roundtable-operator`,
+  `roundtable-operator-dashboard`), not the pod hash.
+- `normalized-signature`: the error message with volatile parts stripped —
+  task IDs, timestamps, pod suffixes, durations, request IDs all become `*`.
+  `task abc-123 timeout after 1800s` → `task * timeout after *s`.
+
+```bash
+fp=$(printf '%s|%s' "$workload" "$signature" | sha256sum | cut -c1-12)
+```
+
+## The ledger — /vault/NightWatch/ledger.md
+
+Single source of incident history. Create it if missing with this header:
+
+```markdown
+# Night Watch Ledger
+| fingerprint | first-seen | last-seen | count | workload | repo | tier | status | mission/PR | summary |
+|---|---|---|---|---|---|---|---|---|---|
+```
+
+Status values: `observed` → `dispatched` → `fix-pr-open` → `merged` →
+`verified` (error gone next sweep) or `recurred` (came back — re-triage at
+higher priority). Dead ends: `wont-fix`, `not-platform` (with a one-line reason).
+
+Every incident you see tonight gets a row (new) or an updated `last-seen`/`count`
+(known). The ledger is append-friendly markdown — keep rows sorted newest-first.
+
+## Dedup
+
+Before dispatching anything:
+
+1. `grep <fp> /vault/NightWatch/ledger.md` — if status is `dispatched`,
+   `fix-pr-open`, or `merged`, do NOT re-dispatch. Update `last-seen` and move on.
+   If `verified` but now recurring, set `recurred` — it may be dispatched again.
+2. `kubectl get missions -n roundtable -l night-watch/fingerprint=<fp>` —
+   an existing non-failed Mission means it's already in flight.
+
+## Ranking
+
+Score each new/recurred incident; dispatch the top ≤ 3:
+
+1. **Recurrence** — `recurred` after a "fix" outranks everything (our fix was wrong)
+2. **Blast radius** — operator/chain failures > single-knight failures > cosmetic
+3. **Frequency** — events/24h
+4. **Fixability** — clear signature + obvious owning repo beats a mystery
+
+Skip (ledger `not-platform`): bad task prompts, model-provider outages,
+transient infra (node reboot) — anything a repo PR can't fix.
+
+## Hard limits — check BEFORE dispatching
+
+- **Max 3 Missions per night.** Quality over coverage; the rest wait in the ledger.
+- **Cost cap $10:** query `sum(increase(pi_knight_llm_cost_dollars_total[24h]))`
+  (see telemetry-queries). If ≥ 10, dispatch NOTHING tonight; record
+  `cost-cap-hit` in the ledger and say so in your output.
+
+## Repo routing and tiers
+
+| Target | Repo | Fixer | Tier |
+|---|---|---|---|
+| pi-knight runtime (task.failed, timeouts, entrypoint) | dapperdivers/pi-knight | coder-1 | 2 |
+| dashboard API/UI | dapperdivers/roundtable-ui | coder-1 | 2 |
+| skills/prompts | dapperdivers/roundtable-arsenal | coder-1 | 1 |
+| operator (reconcile errors, CRD logic) | dapperdivers/roundtable | coder-2 | 3 |
+| nats-bridge | dapperdivers/nats-bridge | coder-2 | 2 |
+| deployment config (env, resources, model names) | dapperdivers/dapper-cluster — `kubernetes/apps/roundtable/**` ONLY | coder-2 | 1 |
+
+## Dispatch — Mission CR
+
+Mode is set by your task text. In **DIAGNOSIS mode**: full triage + ledger, but
+create NO Missions. In **DISPATCH mode**, apply:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: ai.roundtable.io/v1alpha1
+kind: Mission
+metadata:
+  name: nw-<fp>
+  namespace: roundtable
+  labels:
+    night-watch/fingerprint: "<fp>"
+    night-watch/repo: "<short-repo-name>"
+    night-watch/tier: "<1|2|3>"
+spec:
+  objective: "Night Watch fix: <one-line summary>"
+  briefing: |
+    Read the coding/night-watch-fix skill first and follow it exactly.
+
+    Incident fingerprint: <fp> (tier <N>)
+    Target repo: <org/repo>
+    Workload: <workload>
+    Occurrences: <count> in 24h
+
+    Evidence:
+    <the 3-5 most informative raw log lines / metric values — verbatim>
+
+    Diagnosis hypothesis:
+    <your best root-cause analysis: file/area if you can tell, what changed>
+
+    Definition of done: PR opened against <org/repo> with the fix and a test,
+    PR body includes "Night-Watch-Fingerprint: <fp>". If you conclude this is
+    NOT a real bug, say so explicitly with reasoning instead of forcing a PR.
+  knights:
+    - name: <coder-1|coder-2>
+  roundTableRef: personal
+  costBudgetUSD: "3"
+  timeout: 7200
+  ttl: 172800
+  retainResults: true
+EOF
+```
+
+Then set the ledger row to `dispatched` with the mission name.
+
+## Output
+
+Your step output is consumed by the report step. Emit compact, factual markdown:
+incidents seen (with fps), dispatched (with mission names), skipped (with reasons),
+ledger deltas, verification results, total fleet cost. No filler.

--- a/watch/night-watch-triage/SKILL.md
+++ b/watch/night-watch-triage/SKILL.md
@@ -74,14 +74,21 @@ transient infra (node reboot) — anything a repo PR can't fix.
 
 ## Repo routing and tiers
 
+Fixes go to the **roundtable-dev team** — the table that owns the platform.
+Missions reach knights on any table (dispatch uses the knight's own subjects).
+
 | Target | Repo | Fixer | Tier |
 |---|---|---|---|
-| pi-knight runtime (task.failed, timeouts, entrypoint) | dapperdivers/pi-knight | coder-1 | 2 |
-| dashboard API/UI | dapperdivers/roundtable-ui | coder-1 | 2 |
-| skills/prompts | dapperdivers/roundtable-arsenal | coder-1 | 1 |
-| operator (reconcile errors, CRD logic) | dapperdivers/roundtable | coder-2 | 3 |
-| nats-bridge | dapperdivers/nats-bridge | coder-2 | 2 |
-| deployment config (env, resources, model names) | dapperdivers/dapper-cluster — `kubernetes/apps/roundtable/**` ONLY | coder-2 | 1 |
+| pi-knight runtime (task.failed, timeouts, entrypoint) | dapperdivers/pi-knight | rt-runtime | 2 |
+| dashboard API/UI | dapperdivers/roundtable-ui | rt-ui | 2 |
+| skills/prompts | dapperdivers/roundtable-arsenal | rt-arsenal | 1 |
+| operator (reconcile errors, CRD logic) | dapperdivers/roundtable | rt-operator | 3 |
+| nats-bridge | dapperdivers/nats-bridge | rt-runtime | 2 |
+| deployment config (env, resources, model names) | dapperdivers/dapper-cluster — `kubernetes/apps/roundtable/**` ONLY | rt-operator | 1 |
+
+An incident spanning multiple repos gets ONE Mission to **rt-lead** (the team
+architect) with all the evidence — rt-lead breaks it down for the team. That
+still counts as one of the night's 3 dispatches.
 
 ## Dispatch — Mission CR
 
@@ -119,8 +126,8 @@ spec:
     PR body includes "Night-Watch-Fingerprint: <fp>". If you conclude this is
     NOT a real bug, say so explicitly with reasoning instead of forcing a PR.
   knights:
-    - name: <coder-1|coder-2>
-  roundTableRef: personal
+    - name: <rt-runtime|rt-ui|rt-operator|rt-arsenal|rt-lead>
+  roundTableRef: roundtable-dev
   costBudgetUSD: "3"
   timeout: 7200
   ttl: 172800

--- a/watch/telemetry-queries/SKILL.md
+++ b/watch/telemetry-queries/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: telemetry-queries
+description: Query Prometheus and Victoria Logs for Round Table platform errors. Use during the Night Watch sweep to collect the last 24h of failures from the roundtable namespace.
+---
+
+# Telemetry Queries — Night Watch Collection
+
+In-cluster endpoints (no auth required):
+
+| Source | URL |
+|--------|-----|
+| Prometheus | `http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090` |
+| Victoria Logs | `http://victoria-logs-server.observability.svc.cluster.local:9428` |
+
+## Prometheus
+
+Instant query helper:
+
+```bash
+PROM=http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
+pq() { curl -sf "$PROM/api/v1/query" --data-urlencode "query=$1" | jq -r '.data.result[] | [(.metric | tostring), .value[1]] | @tsv'; }
+```
+
+The queries that matter, in order:
+
+```bash
+# 1. Firing alerts in the roundtable namespace (the curated signal — see the
+#    PrometheusRule 'roundtable' for what these mean)
+pq 'ALERTS{namespace="roundtable", alertstate="firing"}'
+
+# 2. Knight task failures over the sweep window, by knight and status
+pq 'sum by (knight, status) (increase(pi_knight_tasks_total{status=~"error|timeout"}[24h])) > 0'
+
+# 3. Pod restarts and OOM kills in the namespace
+pq 'sum by (pod) (increase(kube_pod_container_status_restarts_total{namespace="roundtable"}[24h])) > 0'
+pq 'max_over_time(kube_pod_container_status_last_terminated_reason{namespace="roundtable", reason="OOMKilled"}[24h]) == 1'
+
+# 4. Fleet LLM spend over the window (input to the cost-cap check)
+pq 'sum(increase(pi_knight_llm_cost_dollars_total[24h]))'
+
+# 5. NATS consumer health
+pq 'pi_knight_nats_connected == 0'
+```
+
+## Victoria Logs (LogsQL)
+
+Stream fields from fluent-bit: `k_namespace_name`, `k_pod_name`, `app`, `stream`.
+pi-knight logs are pino JSON (`level` 50=error 40=warn, `event`, `knight`, `taskId`).
+The dashboard API logs are slog JSON (`level`, `msg`, `error`).
+
+```bash
+VL=http://victoria-logs-server.observability.svc.cluster.local:9428
+vq() { curl -sf "$VL/select/logsql/query" --data-urlencode "query=$1" --data-urlencode "limit=${2:-200}"; }
+
+# Error volume per pod over 24h — start here, it tells you where to dig
+vq 'k_namespace_name:roundtable _time:24h (level:50 OR level:error OR "level\":50") | stats by (k_pod_name) count() errors' 50
+
+# Pull the actual error lines for a noisy pod (keep limit small; you have
+# limited context — aggregate first, sample second)
+vq 'k_namespace_name:roundtable k_pod_name:<pod> _time:24h (level:50 OR "task.failed" OR "task.timeout")' 30
+
+# Operator reconcile errors (controller-runtime JSON, level:error)
+vq 'k_namespace_name:roundtable k_pod_name:roundtable-operator* _time:24h "ERROR"' 30
+```
+
+If a field filter returns nothing, the JSON probably wasn't parsed into fields —
+fall back to substring matching (`"task.failed"`, `"\"level\":50"`), which always works.
+
+## Discipline
+
+- **Aggregate before sampling.** `stats by (...) count()` first; only fetch raw
+  lines for the top offenders. Never pull thousands of lines into context.
+- Scope every query to `k_namespace_name:roundtable` / `namespace="roundtable"`.
+- Distinguish *task content failures* (a knight's task text was bad — not a
+  platform bug) from *platform failures* (crash, timeout, disconnect, 5xx —
+  Night Watch's actual quarry). Read the error payloads before deciding.


### PR DESCRIPTION
Phase 0 of the Night Watch overnight self-fixing system.

- **watch/telemetry-queries** — exact Prometheus + Victoria Logs (LogsQL) recipes for the nightly sweep, scoped to the roundtable namespace, aggregate-before-sample discipline
- **watch/night-watch-triage** — fingerprinting rules, /vault/NightWatch/ledger.md schema, dedup via ledger + Mission labels, ranking rubric, 3-Mission/night + $10/night caps, repo routing/tier table, Mission CR dispatch template
- **coding/night-watch-fix** — per-repo verify commands, branch/PR conventions with machine-readable Night-Watch-Fingerprint trailer, automerge policy (phase 2: human merges), protected-path list

Consumed by the new `watchman` knight and `night-watch` Chain landing in dapper-cluster.