### PR TITLE
feat: default planner-generated knights to cheap OpenRouter model

### DIFF
--- a/operator/planner.md
+++ b/operator/planner.md
@@ -56,7 +56,7 @@ You MUST output valid JSON matching this schema:
       "name": "knight-name",
       "domain": "security",
       "role": "reconnaissance",
-      "model": "claude-sonnet-4-20250514",
+      "model": "openrouter/deepseek/deepseek-v3.2",
       "nixPackages": ["nmap", "curl", "jq"],
       "skills": ["security/reconnaissance.md", "shared/base.md"],
       "concurrency": 2,
@@ -98,7 +98,11 @@ The infrastructure handles installation and mounting. You just reason about **wh
 
 ## Model Selection Guide
 
-- **Research/analysis**: claude-sonnet-4-20250514 (fast, good reasoning)
-- **Complex implementation**: claude-sonnet-4-20250514 (code generation)
-- **Critical decisions**: claude-opus-4-20250514 (deep reasoning, expensive)
-- **Simple tasks**: claude-haiku-35-20241022 (fast, cheap)
+**Default: omit `model` entirely** — the knight inherits the fleet's base-template
+model (a cheap OpenRouter model chosen for testing). Only set a model when the
+task genuinely needs more capability:
+
+- **Most tasks (default)**: omit `model` — inherits base template (cheap, OpenRouter)
+- **Explicit cheap choice**: openrouter/deepseek/deepseek-v3.2
+- **Harder reasoning/implementation**: openrouter/anthropic/claude-haiku-4.5
+- **Critical decisions only**: openrouter/anthropic/claude-sonnet-4.5 (expensive — justify in the plan)


### PR DESCRIPTION
The planner skill's example and Model Selection Guide told the planner LLM to set `claude-sonnet-4-20250514` on every generated knight, which overrides the fleet's cheap base-template model (`openrouter/deepseek/deepseek-v3.2` in dapper-cluster).

For testing, generated knights should default to the cheap OpenRouter model:

- Example knight now shows `openrouter/deepseek/deepseek-v3.2`
- Model Selection Guide now says **omit `model` to inherit the base template** (the cheap default), with an explicit escalation ladder (deepseek → haiku-4.5 → sonnet-4.5 via OpenRouter) only when justified

Arsenal fast path: live ~5 minutes after merge (git-sync, no build).

Companion PR (operator prompt example): see roundtable repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)