### PR TITLE
feat: evidence-verification rules as durable skill content

### DIFF
--- a/infra/daily-ops-report/SKILL.md
+++ b/infra/daily-ops-report/SKILL.md
@@ -8,6 +8,26 @@ description: >
 
 Generate a daily ops report covering cluster health, GitOps state, deployments, and maintenance pipeline. Output MUST conform to the shared `daily-reports` JSON contract.
 
+## Evidence Rules (mandatory — see `shared/evidence-verification`)
+
+These three have each produced a corrupted briefing; violating them is a
+failed report:
+
+1. **AGE ≠ duration.** The kubectl/flux AGE column is the resource's age,
+   never a failure duration. Durations come from
+   `status.conditions[].lastTransitionTime` or events. ("emqx stalled 507
+   days" was a 2-day-old failure on a 507-day-old kustomization.)
+2. **Re-verify before incrementing.** Any "Still pending / ⏳ Day N" item must
+   be re-checked today with the command that found it. Not reproducing →
+   `RESOLVED:`, never a bigger counter.
+3. **Flux not-ready ≠ workload down.** Check the pods before claiming
+   impact; if pods are Running/Ready, scope the finding to reconciliation
+   only. (zigbee2mqtt was Running while briefings called home automation
+   degraded.)
+
+Also: a chronic unresolved incident (node down for days) stays in the
+headline every day — "focus on changes" never buries an active outage.
+
 ## Report Sections (Priority Order)
 
 Generate each section below. Lead every section with a traffic light status: 🔴 RED / 🟡 YELLOW / 🟢 GREEN.

--- a/shared/daily-reports/SKILL.md
+++ b/shared/daily-reports/SKILL.md
@@ -77,6 +77,15 @@ Every daily report MUST be a JSON object matching this schema. See [`assets/cont
 | `data_sources` | array | ✅ | Sources consulted (APIs, sites, feeds) |
 | `confidence` | enum | ✅ | `high`, `medium`, or `low` |
 
+### Resolutions (mandatory — see `shared/evidence-verification`)
+
+If anything reported on a previous day is now fixed/closed/no longer present,
+the `highlights` array MUST lead with an entry starting exactly `RESOLVED: `
+for each such item. Resolutions are first-class signal: downstream synthesis
+only sees your highlights, and a dropped resolution becomes a phantom issue
+that is carried forward indefinitely. RESOLVED entries never count against
+any highlight-count guidance.
+
 ### Priority Guidelines
 
 - **high** — Requires Tim's attention today. Actionable items, active threats, significant changes.

--- a/shared/evidence-verification/SKILL.md
+++ b/shared/evidence-verification/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: evidence-verification
+description: >
+  Mandatory evidence rules for any report or briefing that makes factual claims.
+  Prevents the known corruption modes: AGE-column misreads, stale Day-N counters,
+  Flux-status-as-outage claims, dropped resolutions, and uncited numbers.
+---
+
+# Evidence Verification — Report Integrity Rules
+
+These rules are **mandatory** whenever you produce a report, briefing, or
+summary that makes factual claims. They exist because each one maps to a real
+corruption incident in a published briefing. Violating them produces a
+fabricated briefing.
+
+## Rule 1 — AGE is not a duration
+
+The kubectl/flux `AGE` column is the **resource's** age — how long the object
+has existed — not how long a problem has existed. A 507-day-old kustomization
+that started failing yesterday has been broken for one day, not 507.
+
+- NEVER report AGE as a stall, failure, or outage duration.
+- Get problem durations from `status.conditions[].lastTransitionTime`,
+  events, or your own prior reports' first-seen dates.
+
+## Rule 2 — Re-verify before you increment
+
+Before carrying any tracked item forward ("⏳ Day N", "Still pending",
+"Day 139+"), **re-run the check that originally found it**, today.
+
+- Still reproduces → carry it forward and increment.
+- No longer reproduces → report it as `RESOLVED:` — do not silently drop it,
+  and never increment a counter from memory or from yesterday's report alone.
+
+## Rule 3 — Control-plane status is not workload status
+
+A Flux Kustomization/HelmRelease that is `False`/not-ready tells you GitOps
+reconciliation has a problem. It says **nothing** about whether the workload
+is up.
+
+- Check the actual pods (`kubectl get pods ...`) before claiming a service is
+  degraded, down, or "failing silently".
+- If pods are Running and Ready, say so explicitly and scope the finding to
+  reconciliation only.
+
+## Rule 4 — Resolutions are first-class signal
+
+When something you previously reported is fixed, closed, or no longer present,
+that is one of the most valuable things you can report.
+
+- Lead your summary with a `RESOLVED: <item>` bullet for each such item.
+- `RESOLVED:` bullets never count against any bullet-count cap and must never
+  be dropped for space — compression that loses a resolution creates a
+  phantom issue that haunts every future report.
+
+## Rule 5 — No number without a source
+
+Every number you print — day counts, durations, versions, counts of anything —
+must be traceable to a command you ran today, a file you read today, or an
+explicitly cited prior report.
+
+- If you cannot point at the source, do not print the number.
+- Estimates must be labeled as estimates.
+
+## Rule 6 — Chronic is still critical
+
+"Focus on changes" never demotes an ongoing incident. A node that has been
+down for four days belongs in the headline every day until it is fixed, above
+new-but-cosmetic findings. If your report has a "stale items" section, an
+active outage never goes there.
+
+## Rule 7 — Your instructions can be stale
+
+Task prompts and skills are written at a point in time. If evidence you gather
+today (vault files, cluster state, calendars) contradicts a fact stated in
+your instructions, **trust the evidence**, say you did, and flag the stale
+instruction in your report so it gets fixed.

--- a/wellness/prenatal-newborn-wellness/SKILL.md
+++ b/wellness/prenatal-newborn-wellness/SKILL.md
@@ -8,6 +8,15 @@ description: >
 
 **Comprehensive support for pregnancy through first 90 days of newborn care.**
 
+> ## ⚠️ CURRENT STATUS — READ FIRST
+>
+> **Emma was born April 14, 2026. The prenatal phase is OVER.**
+> Compute her age in weeks/days from 2026-04-14 and use ONLY the
+> postpartum/newborn guidance below. Never calculate pregnancy weeks, never
+> reference the due date, hospital bags, or labor signs. If any instruction
+> or prior report implies she is unborn, it is stale — trust this status
+> (and the vault: `/vault/Personal/Family/Emma.md`).
+
 ## Overview
 
 This skill enables AI agents to provide evidence-based wellness guidance through two critical phases:
@@ -132,13 +141,12 @@ Detailed guides in `/references/` directory:
 ```yaml
 # User profile for personalization
 pregnancy:
+  status: "complete"  # Emma arrived — prenatal functions are historical only
   due_date: "2026-04-29"
-  current_week: 34
-  trimester: 3
-  
+
 baby:
   name: "Emma"
-  birth_date: null  # Set after birth
+  birth_date: "2026-04-14"
   
 mother:
   name: "Sara"


### PR DESCRIPTION
## What

Phase-2 item from the briefing-hardening handoff: the forensic pass's verification rules become durable skill content instead of living only in the morning-briefing chain prompts.

- **New `shared/evidence-verification/SKILL.md`** — seven mandatory report-integrity rules, each mapping to a real corruption incident:
  1. AGE column ≠ duration ("emqx stalled 507 days" was 2)
  2. Re-verify before incrementing Day-N counters (phantom wazuh/docling "Day 139+")
  3. Flux not-ready ≠ workload down (zigbee2mqtt was Running throughout)
  4. RESOLVED: bullets are first-class, exempt from bullet caps (resolutions died in the summary hop)
  5. No number without a source
  6. Chronic incidents stay in the headline (gpu-1 wedged 47h vs "healthy baseline")
  7. Evidence beats stale instructions (Gareth's prompt says Emma is unborn)
- **`infra/daily-ops-report`** — the three infra-specific rules inlined for Tristan with the incident examples.
- **`shared/daily-reports`** — `highlights` must lead with `RESOLVED:` entries; documented why (downstream synthesis only sees highlights).
- **`wellness/prenatal-newborn-wellness`** — pregnancy-era rot fixed: status banner + config now say Emma was born 2026-04-14, prenatal phase complete.

## Notes

- Arsenal merges are live in ≤5m via git-sync — this is deliberately additive/corrective, no skill renames or schema changes.
- Companion chain-prompt changes (same rules in `morning-briefing.yaml` task text) are in the dapper-cluster write-up `docs/briefing-hardening-quickwins.md` in the workspace repo, for Derek's cluster session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)